### PR TITLE
recipe dependencies

### DIFF
--- a/recipe.yaml
+++ b/recipe.yaml
@@ -10,9 +10,9 @@ Manifests:
       - URI: s3://gg-dev-artifacts/$componentName/$version/aws.greengrass.mqtt.bridge.jar
     Dependencies:
       aws.greengrass.certificate.manager:
-        VersionRequirement: ^0.0
+        VersionRequirement: >=0.0.0
         DependencyType: HARD
       #TODO: remove mqtt dependency
       aws.greengrass.mqtt:
-        VersionRequirement: ^0.0
+        VersionRequirement: >=0.0.0
         DependencyType: HARD


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add DCM and mqtt broker as dependencies

**Why is this change necessary:**
To get certificate and CA from DCM on startup, and connect to mqtt broker on startup

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
