### PR TITLE
MQTTClient connect retry logic

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
@@ -36,6 +36,7 @@ import java.security.cert.CertificateException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
 
 @ImplementsService(name = MQTTBridge.SERVICE_NAME)
@@ -47,6 +48,7 @@ public class MQTTBridge extends PluginService {
     private final MessageBridge messageBridge;
     private final Kernel kernel;
     private final MQTTClientKeyStore mqttClientKeyStore;
+    private final ScheduledExecutorService ses;
     private MQTTClient mqttClient;
     private PubSubClient pubSubClient;
     private IoTCoreClient ioTCoreClient;
@@ -62,19 +64,21 @@ public class MQTTBridge extends PluginService {
      * @param topicMapping       mapping of mqtt topics to iotCore/pubsub topics
      * @param pubSubIPCAgent     IPC agent for pubsub
      * @param iotMqttClient      mqtt client for iot core
-     * @param kernel             greengrass kernel
+     * @param kernel             Greengrass kernel
      * @param mqttClientKeyStore KeyStore for MQTT Client
+     * @param ses                Scheduled executor service
      */
     @Inject
     public MQTTBridge(Topics topics, TopicMapping topicMapping, PubSubIPCEventStreamAgent pubSubIPCAgent,
-                      MqttClient iotMqttClient, Kernel kernel, MQTTClientKeyStore mqttClientKeyStore) {
+                      MqttClient iotMqttClient, Kernel kernel, MQTTClientKeyStore mqttClientKeyStore,
+                      ScheduledExecutorService ses) {
         this(topics, topicMapping, new MessageBridge(topicMapping), pubSubIPCAgent, iotMqttClient, kernel,
-                mqttClientKeyStore);
+                mqttClientKeyStore, ses);
     }
 
     protected MQTTBridge(Topics topics, TopicMapping topicMapping, MessageBridge messageBridge,
                          PubSubIPCEventStreamAgent pubSubIPCAgent, MqttClient iotMqttClient, Kernel kernel,
-                         MQTTClientKeyStore mqttClientKeyStore) {
+                         MQTTClientKeyStore mqttClientKeyStore, ScheduledExecutorService ses) {
         super(topics);
         this.topicMapping = topicMapping;
         this.kernel = kernel;
@@ -82,6 +86,7 @@ public class MQTTBridge extends PluginService {
         this.messageBridge = messageBridge;
         this.pubSubClient = new PubSubClient(pubSubIPCAgent);
         this.ioTCoreClient = new IoTCoreClient(iotMqttClient);
+        this.ses = ses;
     }
 
     @Override
@@ -145,7 +150,7 @@ public class MQTTBridge extends PluginService {
 
         try {
             if (mqttClient == null) {
-                mqttClient = new MQTTClient(this.config, mqttClientKeyStore);
+                mqttClient = new MQTTClient(this.config, mqttClientKeyStore, this.ses);
             }
             mqttClient.start();
             messageBridge.addOrReplaceMessageClient(TopicMapping.TopicType.LocalMqtt, mqttClient);

--- a/src/main/java/com/aws/greengrass/mqttbridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/clients/MQTTClient.java
@@ -26,6 +26,9 @@ import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import java.security.KeyStoreException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import javax.inject.Inject;
 import javax.net.ssl.SSLSocketFactory;
@@ -46,6 +49,8 @@ public class MQTTClient implements MessageClient {
     private final String clientId;
 
     private final MqttClientPersistence dataStore;
+    private final ScheduledExecutorService ses;
+    private ScheduledFuture<?> connectFuture;
     private MqttClient mqttClientInternal;
     @Getter(AccessLevel.PROTECTED)
     private Set<String> subscribedLocalMqttTopics = new HashSet<>();
@@ -83,11 +88,13 @@ public class MQTTClient implements MessageClient {
      *
      * @param topics             topics passed in by Nucleus
      * @param mqttClientKeyStore KeyStore for MQTT Client
+     * @param ses                Scheduled executor service
      * @throws MQTTClientException if unable to create client for the mqtt broker
      */
     @Inject
-    public MQTTClient(Topics topics, MQTTClientKeyStore mqttClientKeyStore) throws MQTTClientException {
-        this(topics, mqttClientKeyStore, null);
+    public MQTTClient(Topics topics, MQTTClientKeyStore mqttClientKeyStore, ScheduledExecutorService ses)
+            throws MQTTClientException {
+        this(topics, mqttClientKeyStore, ses, null);
         // TODO: Handle the case when serverUri is modified
         try {
             this.mqttClientInternal = new MqttClient(serverUri, clientId, dataStore);
@@ -96,7 +103,8 @@ public class MQTTClient implements MessageClient {
         }
     }
 
-    protected MQTTClient(Topics topics, MQTTClientKeyStore mqttClientKeyStore, MqttClient mqttClient) {
+    protected MQTTClient(Topics topics, MQTTClientKeyStore mqttClientKeyStore, ScheduledExecutorService ses,
+                         MqttClient mqttClient) {
         this.mqttClientInternal = mqttClient;
         this.dataStore = new MemoryPersistence();
         this.serverUri = Coerce.toString(
@@ -106,6 +114,8 @@ public class MQTTClient implements MessageClient {
                 topics.findOrDefault(DEFAULT_CLIENT_ID, KernelConfigResolver.CONFIGURATION_CONFIG_KEY, CLIENT_ID_KEY));
         this.mqttClientKeyStore = mqttClientKeyStore;
         this.mqttClientKeyStore.listenToUpdates(this::reset);
+        this.ses = ses;
+        mqttClientInternal.setCallback(mqttCallback);
     }
 
     private void reset() {
@@ -119,16 +129,17 @@ public class MQTTClient implements MessageClient {
         }
 
         try {
-            readKeyStoreAndConnect();
-        } catch (KeyStoreException | MqttException e) {
-            LOGGER.atError().setCause(e).log("Failed to connect with updated KeyStore");
-            return;
+            connectAndSubscribe();
+        } catch (KeyStoreException e) {
+            throw new RuntimeException(e);
         }
-
-        resubscribe();
     }
 
-    private void readKeyStoreAndConnect() throws KeyStoreException, MqttException {
+    private synchronized void connectAndSubscribe() throws KeyStoreException {
+        if (connectFuture != null) {
+            connectFuture.cancel(true);
+        }
+
         //TODO: persistent session could be used
         connOpts.setCleanSession(true);
 
@@ -138,32 +149,27 @@ public class MQTTClient implements MessageClient {
         }
 
         LOGGER.atInfo().kv("uri", serverUri).kv(CLIENT_ID_KEY, clientId).log("Connecting to broker");
-        doConnect();
+        connectFuture = ses.schedule(this::reconnectAndResubscribe, 0, TimeUnit.SECONDS);
     }
 
     private synchronized void doConnect() throws MqttException {
         if (!mqttClientInternal.isConnected()) {
             mqttClientInternal.connect(connOpts);
+            LOGGER.atInfo().kv("uri", serverUri).kv(CLIENT_ID_KEY, clientId).log("Connected to broker");
         }
     }
 
     /**
      * Start the {@link MQTTClient}.
      *
-     * @throws MQTTClientException if unable to connect to the broker
+     * @throws RuntimeException if the client cannot load the KeyStore used to connect to the broker.
      */
-    public void start() throws MQTTClientException {
+    public void start() {
         try {
-            // TODO: need retry logic here if we want to remove dependency on broker
-            readKeyStoreAndConnect();
-        } catch (MqttException | KeyStoreException e) {
-            LOGGER.atError().kv("uri", serverUri).kv(CLIENT_ID_KEY, clientId).log("Unable to connect to broker");
-            throw new MQTTClientException("Unable to connect to MQTT broker", e);
+            connectAndSubscribe();
+        } catch (KeyStoreException e) {
+            throw new RuntimeException(e);
         }
-        LOGGER.atInfo().kv("uri", serverUri).kv(CLIENT_ID_KEY, clientId).log("Connected to broker");
-
-        mqttClientInternal.setCallback(mqttCallback);
-        resubscribe();
     }
 
     /**

--- a/src/test/java/com/aws/greengrass/mqttbridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqttbridge/MQTTBridgeTest.java
@@ -45,6 +45,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -66,6 +68,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
     private Kernel kernel;
     private GlobalStateChangeListener listener;
     private Server broker;
+    private ScheduledExecutorService ses;
 
     @TempDir
     Path rootDir;
@@ -81,6 +84,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         defaultConfig.setProperty(BrokerConstants.PORT_PROPERTY_NAME, "8883");
         broker = new Server();
         broker.startServer(defaultConfig);
+        ses = new ScheduledThreadPoolExecutor(1);
     }
 
     @AfterEach
@@ -235,7 +239,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         try (MqttClient mockIotMqttClient = mock(MqttClient.class)) {
             mqttBridge =
                     new MQTTBridge(config, mockTopicMapping, mockMessageBridge, mockPubSubIPCAgent, mockIotMqttClient,
-                            mockKernel, mockMqttClientKeyStore);
+                            mockKernel, mockMqttClientKeyStore, ses);
         }
 
         when(config


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
MQTTClient connection retry logic:
There are two cases in which MQTTClient connects to broker - i) service starting and ii) connection lost. In both cases, the same retry logic will be used.
Reconnecting on keystore update (CA update) isn't required, since the client is anyway going to lose connection on CA update and we have reconnection in place for that. So only socket factory is updated on keystore update.

**Why is this change necessary:**
With retry logic on initial connect, the dependency on aws.greengrass.Mqtt has been removed.
The service can be set to ERRORED state if connection isn't successful after multiple retry attempts.

**How was this change tested:**
Tested end to end along with DCM and broker, with a Pubsub component sending message to a GGAD.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
