### PR TITLE
feat: store certificate chain with private key

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttbridge/auth/MQTTClientKeyStore.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/auth/MQTTClientKeyStore.java
@@ -25,7 +25,6 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -107,9 +106,8 @@ public class MQTTClientKeyStore {
         return kpg.generateKeyPair();
     }
 
-    private void updateCert(X509Certificate cert) {
+    private void updateCert(X509Certificate... certChain) {
         try {
-            Certificate[] certChain = {cert};
             keyStore.setKeyEntry(KEY_ALIAS, keyPair.getPrivate(), DEFAULT_KEYSTORE_PASSWORD, certChain);
 
             updateListeners.forEach(UpdateListener::onUpdate); //notify MQTTClient


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
store certificate chain (client certificate, CA certificate) in KeyStore

**Why is this change necessary:**
client needs to present certificate chain when connecting to broker

**How was this change tested:**
updated unit tests pass

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
