### PR TITLE
feat: re-add but deprecate brokerServerUri

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttbridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/clients/MQTTClient.java
@@ -37,6 +37,7 @@ public class MQTTClient implements MessageClient {
     private static final Logger LOGGER = LogManager.getLogger(MQTTClient.class);
     private static final String DEFAULT_BROKER_URI = "ssl://localhost:8883";
     private static final String DEFAULT_CLIENT_ID = "mqtt-bridge-" + Utils.generateRandomString(11);
+    private static final String DEPRECATED_BROKER_URI_KEY = "brokerServerUri"; // DO NOT USE
     public static final String BROKER_URI_KEY = "brokerUri";
     public static final String CLIENT_ID_KEY = "clientId";
     public static final String TOPIC = "topic";
@@ -104,11 +105,15 @@ public class MQTTClient implements MessageClient {
 
     protected MQTTClient(Topics topics, MQTTClientKeyStore mqttClientKeyStore, ExecutorService executorService,
                          IMqttClient mqttClient) {
+        // serverUri should take precedence since brokerServerUri is deprecated
+        String tmpUri = Coerce.toString(
+                topics.findOrDefault(DEFAULT_BROKER_URI, KernelConfigResolver.CONFIGURATION_CONFIG_KEY,
+                        DEPRECATED_BROKER_URI_KEY));
+        this.serverUri = Coerce.toString(
+                topics.findOrDefault(tmpUri, KernelConfigResolver.CONFIGURATION_CONFIG_KEY,
+                        BROKER_URI_KEY));
         this.mqttClientInternal = mqttClient;
         this.dataStore = new MemoryPersistence();
-        this.serverUri = Coerce.toString(
-                topics.findOrDefault(DEFAULT_BROKER_URI, KernelConfigResolver.CONFIGURATION_CONFIG_KEY,
-                        BROKER_URI_KEY));
         this.clientId = Coerce.toString(
                 topics.findOrDefault(DEFAULT_CLIENT_ID, KernelConfigResolver.CONFIGURATION_CONFIG_KEY, CLIENT_ID_KEY));
         this.mqttClientKeyStore = mqttClientKeyStore;

--- a/src/test/java/com/aws/greengrass/mqttbridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqttbridge/MQTTBridgeTest.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.certificatemanager.CertificateManager;
 import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.device.ClientDevicesAuthService;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
@@ -53,8 +54,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -236,18 +235,18 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         Kernel mockKernel = mock(Kernel.class);
         MQTTClientKeyStore mockMqttClientKeyStore = mock(MQTTClientKeyStore.class);
         MQTTBridge mqttBridge;
+
+        Topics config = Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null);
+        config.lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, MQTTClient.BROKER_URI_KEY)
+                .dflt("tcp://localhost:8883");
+        config.lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, MQTTClient.CLIENT_ID_KEY)
+                .dflt(MQTTBridge.SERVICE_NAME);
+
         try (MqttClient mockIotMqttClient = mock(MqttClient.class)) {
             mqttBridge =
                     new MQTTBridge(config, mockTopicMapping, mockMessageBridge, mockPubSubIPCAgent, mockIotMqttClient,
                             mockKernel, mockMqttClientKeyStore, ses);
         }
-
-        when(config
-                .findOrDefault(any(), eq(KernelConfigResolver.CONFIGURATION_CONFIG_KEY), eq(MQTTClient.BROKER_URI_KEY)))
-                .thenReturn("tcp://localhost:8883");
-        when(config
-                .findOrDefault(any(), eq(KernelConfigResolver.CONFIGURATION_CONFIG_KEY), eq(MQTTClient.CLIENT_ID_KEY)))
-                .thenReturn(MQTTBridge.SERVICE_NAME);
 
         ClientDevicesAuthService mockClientAuthService = mock(ClientDevicesAuthService.class);
         when(mockKernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME))


### PR DESCRIPTION
This change re-introduces the brokerServerUri config to avoid
potentially breaking customers. Instead, the bridge will continue to
read the brokerServerUri config. Any value in the brokerUri config will
override the value of brokerServerUri in order to maintain backward
compatibility.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
