### PR TITLE
chore: bump lombok to 1.18.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.10</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Bump lombok version to 1.18.22

**Why is this change necessary:**

I was experiencing the following error in IntelliJ
```
java: You aren't using a compiler supported by lombok, so lombok will not work and has been disabled.
Your processor is: com.sun.proxy.$Proxy32
Lombok supports: OpenJDK javac, ECJ
```

This is related to https://youtrack.jetbrains.com/issue/IDEA-252069, and is fixed in recent lombok versions.

**How was this change tested:**
```
mvn clean verify
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
