### PR TITLE
fix: config reset bug

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
@@ -96,7 +96,7 @@ public class MQTTBridge extends PluginService {
     public void install() {
         this.config.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe((whatHappened, node) -> {
             if (!skipUpdatingMqttTopicMapping(whatHappened, node)) {
-                logger.atDebug().kv("why", whatHappened).kv("node", node).log();
+                logger.atTrace().kv("why", whatHappened).kv("node", node).log();
                 Topics mappingConfigTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY, MQTT_TOPIC_MAPPING);
                 if (mappingConfigTopics.isEmpty()) {
                     logger.debug("Mapping empty");
@@ -193,8 +193,8 @@ public class MQTTBridge extends PluginService {
         if (whatHappened == WhatHappened.timestampUpdated || whatHappened == WhatHappened.interiorAdded) {
             return true;
         }
-        if (node != null && node.getName().equals(BROKER_URI_KEY)) {
-            logger.atDebug().kv("why", whatHappened).kv("node", node)
+        if (node != null && BROKER_URI_KEY.equals(node.getName())) {
+            logger.atTrace().kv("why", whatHappened).kv("node", node)
                     .log("Broker URI update. Skip updating topic mapping");
             return true;
         }

--- a/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
@@ -197,9 +197,8 @@ public class MQTTBridge extends PluginService {
         if (whatHappened == WhatHappened.timestampUpdated || whatHappened == WhatHappened.interiorAdded) {
             return true;
         }
-        if (node != null && BROKER_URI_KEY.equals(node.getName())) {
-            logger.atTrace().kv("why", whatHappened).kv("node", node)
-                    .log("Broker URI update. Skip updating topic mapping");
+        if (node != null && !node.childOf(MQTT_TOPIC_MAPPING)) {
+            logger.atTrace().kv("why", whatHappened).kv("node", node).log("Skip updating topic mapping");
             return true;
         }
         return false;

--- a/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.mqttbridge;
 import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
 import com.aws.greengrass.certificatemanager.certificate.CsrProcessingException;
 import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.ImplementsService;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.device.ClientDevicesAuthService;
@@ -92,6 +93,9 @@ public class MQTTBridge extends PluginService {
     @Override
     public void install() {
         this.config.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe((whatHappened, node) -> {
+            if (whatHappened == WhatHappened.timestampUpdated || whatHappened == WhatHappened.interiorAdded) {
+                return;
+            }
             Topics mappingConfigTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY, MQTT_TOPIC_MAPPING);
             if (mappingConfigTopics.isEmpty()) {
                 logger.debug("Mapping empty");

--- a/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
@@ -92,9 +92,7 @@ public class MQTTBridge extends PluginService {
 
     @Override
     public void install() {
-        configTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY);
-
-        configTopics.subscribe((whatHappened, node) -> {
+        this.config.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe((whatHappened, node) -> {
             Topics mappingConfigTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY, MQTT_TOPIC_MAPPING);
             if (mappingConfigTopics.isEmpty()) {
                 logger.debug("Mapping empty");

--- a/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
@@ -56,7 +56,6 @@ public class MQTTBridge extends PluginService {
     private static final JsonMapper OBJECT_MAPPER =
             JsonMapper.builder().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES).build();
     static final String MQTT_TOPIC_MAPPING = "mqttTopicMapping";
-    private Topics configTopics;
 
     /**
      * Ctr for MQTTBridge.

--- a/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
@@ -7,7 +7,6 @@ package com.aws.greengrass.mqttbridge;
 
 import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
 import com.aws.greengrass.certificatemanager.certificate.CsrProcessingException;
-import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.ImplementsService;
 import com.aws.greengrass.dependency.State;
@@ -39,6 +38,8 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import javax.inject.Inject;
 
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+
 @ImplementsService(name = MQTTBridge.SERVICE_NAME)
 public class MQTTBridge extends PluginService {
     public static final String SERVICE_NAME = "aws.greengrass.clientdevices.mqtt.Bridge";
@@ -55,7 +56,7 @@ public class MQTTBridge extends PluginService {
     private static final JsonMapper OBJECT_MAPPER =
             JsonMapper.builder().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES).build();
     static final String MQTT_TOPIC_MAPPING = "mqttTopicMapping";
-    private Topics mappingConfigTopics;
+    private Topics configTopics;
 
     /**
      * Ctr for MQTTBridge.
@@ -91,10 +92,10 @@ public class MQTTBridge extends PluginService {
 
     @Override
     public void install() {
-        mappingConfigTopics =
-                this.config.lookupTopics(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, MQTT_TOPIC_MAPPING);
+        configTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY);
 
-        mappingConfigTopics.subscribe((whatHappened, node) -> {
+        configTopics.subscribe((whatHappened, node) -> {
+            Topics mappingConfigTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY, MQTT_TOPIC_MAPPING);
             if (mappingConfigTopics.isEmpty()) {
                 logger.debug("Mapping empty");
                 topicMapping.updateMapping(Collections.emptyMap());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently we subscribe to `mqttTopicMapping` that can be removed with a reset `[""]`. 
Preserve the subscription with subscribing to `configuration`

**Why is this change necessary:**
When we reset the configuration for `mqttTopicMapping` using [""], we lose the subscription in the process.
Any further updates to the config are not parsed by Bridge.

**How was this change tested:**
`mvn clean verify`

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
