### PR TITLE
fix: unsubscribe to CDA CA conf

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -207,12 +207,12 @@ public class MQTTBridge extends PluginService {
                                 ClientDevicesAuthService.CERTIFICATES_KEY,
                                 ClientDevicesAuthService.AUTHORITIES_TOPIC));
             } catch (ServiceLoadException e) {
-                logger.atWarn().cause(e).log(String.format(
-                        "Unable to locate %s. "
+                logger.atWarn().cause(e).log(
+                        "Unable to locate {}. "
                                 + "MQTT Bridge may be unable to connect to the broker. "
-                                + "Ensure that %s component is deployed",
+                                + "Ensure that {} component is deployed.",
                         ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME,
-                        ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME));
+                        ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME);
                 return Optional.empty();
             }
         }

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -35,7 +35,9 @@ import java.io.IOException;
 import java.security.KeyStoreException;
 import java.security.cert.CertificateException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import javax.inject.Inject;
 
@@ -161,12 +163,16 @@ public class MQTTBridge extends PluginService {
         private BatchedSubscriber subscriber;
 
         @SuppressWarnings({"unchecked", "PMD.UnusedFormalParameter"})
-        private void onCAChange(WhatHappened what, List<Node> whatChanged) {
-            if (whatChanged.isEmpty()) {
+        private void onCAChange(WhatHappened what, Set<Node> whatChanged) {
+            Topic caTopic;
+            try {
+                caTopic = findCATopic();
+            } catch (ServiceLoadException e) {
+                serviceErrored(e);
                 return;
             }
 
-            List<String> caCerts = (List<String>) whatChanged.get(whatChanged.size() - 1).toPOJO();
+            List<String> caCerts = (List<String>) caTopic.toPOJO();
             if (Utils.isEmpty(caCerts)) {
                 return;
             }

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -207,7 +207,12 @@ public class MQTTBridge extends PluginService {
                                 ClientDevicesAuthService.CERTIFICATES_KEY,
                                 ClientDevicesAuthService.AUTHORITIES_TOPIC));
             } catch (ServiceLoadException e) {
-                logger.atWarn().cause(e).log("unable to locate service");
+                logger.atWarn().cause(e).log(String.format(
+                        "Unable to locate %s. "
+                                + "MQTT Bridge may be unable to connect to the broker. "
+                                + "Ensure that %s component is deployed",
+                        ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME,
+                        ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME));
                 return Optional.empty();
             }
         }

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -199,8 +199,9 @@ public class MQTTBridge extends PluginService {
         private Optional<Topic> findCATopic() {
             try {
                 return Optional.of(kernel
-                        .locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME).getConfig()
-                        .lookup(RUNTIME_STORE_NAMESPACE_TOPIC,
+                        .locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME)
+                        .getRuntimeConfig()
+                        .lookup(
                                 ClientDevicesAuthService.CERTIFICATES_KEY,
                                 ClientDevicesAuthService.AUTHORITIES_TOPIC));
             } catch (ServiceLoadException e) {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -10,6 +10,8 @@ import com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.config.Node;
+import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.dependency.ImplementsService;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.lifecyclemanager.Kernel;
@@ -49,6 +51,7 @@ public class MQTTBridge extends PluginService {
     private final MQTTClientKeyStore mqttClientKeyStore;
     private final LocalMqttClientFactory localMqttClientFactory;
     private final ConfigurationChangeHandler configurationChangeHandler;
+    private final CertificateAuthorityChangeHandler certificateAuthorityChangeHandler;
     private MessageClient localMqttClient;
     private PubSubClient pubSubClient;
     private IoTCoreClient ioTCoreClient;
@@ -90,6 +93,7 @@ public class MQTTBridge extends PluginService {
         this.ioTCoreClient = new IoTCoreClient(iotMqttClient, executorService);
         this.localMqttClientFactory = localMqttClientFactory;
         this.configurationChangeHandler = new ConfigurationChangeHandler();
+        this.certificateAuthorityChangeHandler = new CertificateAuthorityChangeHandler();
     }
 
     @Override
@@ -107,24 +111,8 @@ public class MQTTBridge extends PluginService {
         }
 
         try {
-            kernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME).getConfig()
-                    .lookup(RUNTIME_STORE_NAMESPACE_TOPIC, ClientDevicesAuthService.CERTIFICATES_KEY,
-                            ClientDevicesAuthService.AUTHORITIES_TOPIC).subscribe((why, newv) -> {
-                try {
-                    List<String> caPemList = (List<String>) newv.toPOJO();
-                    if (Utils.isEmpty(caPemList)) {
-                        logger.debug("CA list null or empty");
-                        return;
-                    }
-                    mqttClientKeyStore.updateCA(caPemList);
-                } catch (IOException | CertificateException | KeyStoreException e) {
-                    logger.atError("Invalid CA list").kv("CAList", Coerce.toString(newv)).log();
-                    serviceErrored(String.format("Invalid CA list. %s", e.getMessage()));
-                }
-            });
+            certificateAuthorityChangeHandler.start();
         } catch (ServiceLoadException e) {
-            logger.atError().cause(e).log("Unable to locate {} service while subscribing to CA certificates",
-                    ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME);
             serviceErrored(e);
             return;
         }
@@ -149,6 +137,7 @@ public class MQTTBridge extends PluginService {
 
     @Override
     public void shutdown() {
+        certificateAuthorityChangeHandler.stop();
         mqttClientKeyStore.shutdown();
 
         messageBridge.removeMessageClient(TopicMapping.TopicType.LocalMqtt);
@@ -164,6 +153,61 @@ public class MQTTBridge extends PluginService {
         messageBridge.removeMessageClient(TopicMapping.TopicType.IotCore);
         if (ioTCoreClient != null) {
             ioTCoreClient.stop();
+        }
+    }
+
+    public class CertificateAuthorityChangeHandler {
+
+        private BatchedSubscriber subscriber;
+
+        @SuppressWarnings({"unchecked", "PMD.UnusedFormalParameter"})
+        private void onCAChange(WhatHappened what, List<Node> whatChanged) {
+            if (whatChanged.isEmpty()) {
+                return;
+            }
+
+            List<String> caCerts = (List<String>) whatChanged.get(whatChanged.size() - 1).toPOJO();
+            if (Utils.isEmpty(caCerts)) {
+                return;
+            }
+
+            logger.atDebug().kv("numCaCerts", caCerts.size()).log("CA update received");
+            try {
+                mqttClientKeyStore.updateCA(caCerts);
+            } catch (IOException | CertificateException | KeyStoreException e) {
+                serviceErrored(e);
+            }
+        }
+
+        /**
+         * Begin listening and responding to CDA CA changes.
+         *
+         * <p>This operation is idempotent.
+         *
+         * @throws ServiceLoadException if CDA service could not be loaded
+         */
+        public void start() throws ServiceLoadException {
+            if (subscriber == null) {
+                subscriber = new BatchedSubscriber(findCATopic(), this::onCAChange);
+            }
+            subscriber.subscribe();
+        }
+
+        private Topic findCATopic() throws ServiceLoadException {
+            return kernel
+                    .locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME).getConfig()
+                    .lookup(RUNTIME_STORE_NAMESPACE_TOPIC,
+                            ClientDevicesAuthService.CERTIFICATES_KEY,
+                            ClientDevicesAuthService.AUTHORITIES_TOPIC);
+        }
+
+        /**
+         * Stop listening to CDA CA changes.
+         */
+        public void stop() {
+            if (subscriber != null) {
+                subscriber.unsubscribe();
+            }
         }
     }
 

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
@@ -431,7 +431,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         config.lookup(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_BROKER_URI)
                 .dflt("tcp://localhost:8883");
         config.lookup(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_CLIENT_ID)
-                .dflt(MQTTBridge.SERVICE_NAME);
+                .dflt("clientId");
 
         localMqttClientFactory.setConfig(BridgeConfig.fromTopics(config));
 

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
@@ -9,7 +9,6 @@ import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
 import com.aws.greengrass.clientdevices.auth.CertificateManager;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
-import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.config.UpdateBehaviorTree;
@@ -75,7 +74,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -386,12 +384,11 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         MQTTBridge mqttBridge;
         LocalMqttClientFactory localMqttClientFactory = new LocalMqttClientFactory(mockMqttClientKeyStore, ses);
 
-        Context context = new Context();
-        try {
-            Topics config = Topics.of(context, KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null);
-            config.lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_BROKER_URI)
+        try (Context context = new Context()) {
+            Topics config = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
+            config.lookup(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_BROKER_URI)
                     .dflt("tcp://localhost:8883");
-            config.lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_CLIENT_ID)
+            config.lookup(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_CLIENT_ID)
                     .dflt("clientId");
 
             localMqttClientFactory.setConfig(BridgeConfig.fromTopics(config));
@@ -438,8 +435,6 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
                     .withValue(Arrays.asList("CA1", "CA2"));
             context.waitForPublishQueueToClear();
             verify(mockMqttClientKeyStore, never()).updateCA(caListCaptor.capture());
-        } finally {
-            context.shutdown();
         }
     }
 
@@ -506,12 +501,11 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         MQTTBridge mqttBridge;
         LocalMqttClientFactory localMqttClientFactory = new LocalMqttClientFactory(mockMqttClientKeyStore, ses);
 
-        Context context = new Context();
-        try {
-            Topics config = Topics.of(context, KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null);
-            config.lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_BROKER_URI)
+        try (Context context = new Context()) {
+            Topics config = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
+            config.lookup(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_BROKER_URI)
                     .dflt("tcp://localhost:8883");
-            config.lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_CLIENT_ID)
+            config.lookup(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_CLIENT_ID)
                     .dflt("clientId");
 
             localMqttClientFactory.setConfig(BridgeConfig.fromTopics(config));
@@ -539,8 +533,6 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
             context.waitForPublishQueueToClear();
             ArgumentCaptor<List<String>> caListCaptor = ArgumentCaptor.forClass(List.class);
             verify(mockMqttClientKeyStore, never()).updateCA(caListCaptor.capture());
-        } finally {
-            context.shutdown();
         }
     }
 

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
@@ -563,11 +563,11 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         when(mockKernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME))
                 .thenReturn(mockClientAuthService);
         Topics mockClientAuthConfig = mock(Topics.class);
-        when(mockClientAuthService.getConfig()).thenReturn(mockClientAuthConfig);
+        when(mockClientAuthService.getRuntimeConfig()).thenReturn(mockClientAuthConfig);
 
         Topic caTopic = Topic.of(context, "authorities", Arrays.asList("CA1", "CA2"));
         when(mockClientAuthConfig
-                .lookup(MQTTBridge.RUNTIME_STORE_NAMESPACE_TOPIC, ClientDevicesAuthService.CERTIFICATES_KEY,
+                .lookup(ClientDevicesAuthService.CERTIFICATES_KEY,
                         ClientDevicesAuthService.AUTHORITIES_TOPIC)).thenReturn(caTopic);
 
         mqttBridge.install();

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
@@ -379,10 +379,8 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         verify(mockMqttClientKeyStore).updateCA(caListCaptor.capture());
         assertThat(caListCaptor.getValue(), is(Arrays.asList("CA1", "CA2")));
 
-        caTopic = Topic.of(context, "authorities", Collections.emptyList());
-        when(mockClientAuthConfig
-                .lookup(MQTTBridge.RUNTIME_STORE_NAMESPACE_TOPIC, ClientDevicesAuthService.CERTIFICATES_KEY,
-                        ClientDevicesAuthService.AUTHORITIES_TOPIC)).thenReturn(caTopic);
+        caTopic.withValue(Collections.emptyList());
+
         reset(mockMqttClientKeyStore);
         mqttBridge.install();
         mqttBridge.startup();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Fixes bug where CDA CA subscriptions accumulate for every call to `install`.  Additionally, CDA subscription code has been consolidated to a class, `CertificateAuthorityChangeHandler`, and has been refactored to use `BatchedSubscriber`.

**Why is this change necessary:**

To prevent duplicate subscriptions to CDA topics

**How was this change tested:**

unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
