### PR TITLE
fix: remove client certificate rotate callback

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttbridge/auth/MQTTClientKeyStore.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/auth/MQTTClientKeyStore.java
@@ -56,7 +56,7 @@ public class MQTTClientKeyStore {
 
     @FunctionalInterface
     public interface UpdateListener {
-        void onUpdate();
+        void onCAUpdate();
     }
 
     /**
@@ -109,8 +109,6 @@ public class MQTTClientKeyStore {
     private void updateCert(X509Certificate... certChain) {
         try {
             keyStore.setKeyEntry(KEY_ALIAS, keyPair.getPrivate(), DEFAULT_KEYSTORE_PASSWORD, certChain);
-
-            updateListeners.forEach(UpdateListener::onUpdate); //notify MQTTClient
         } catch (KeyStoreException e) {
             LOGGER.atError("Unable to store generated cert", e);
         }
@@ -139,7 +137,7 @@ public class MQTTClientKeyStore {
             keyStore.setCertificateEntry("CA" + i, caCert);
         }
 
-        updateListeners.forEach(UpdateListener::onUpdate); //notify MQTTClient
+        updateListeners.forEach(UpdateListener::onCAUpdate); //notify MQTTClient
     }
 
     private X509Certificate pemToX509Certificate(String certPem) throws IOException, CertificateException {
@@ -156,7 +154,7 @@ public class MQTTClientKeyStore {
      * Add listener to listen to KeyStore updates.
      * @param listener listener method
      */
-    public synchronized void listenToUpdates(UpdateListener listener) {
+    public synchronized void listenToCAUpdates(UpdateListener listener) {
         updateListeners.add(listener);
     }
 

--- a/src/main/java/com/aws/greengrass/mqttbridge/auth/MQTTClientKeyStore.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/auth/MQTTClientKeyStore.java
@@ -108,6 +108,7 @@ public class MQTTClientKeyStore {
 
     private void updateCert(X509Certificate... certChain) {
         try {
+            LOGGER.atDebug().log("Storing new client certificate to be used on next connect attempt");
             keyStore.setKeyEntry(KEY_ALIAS, keyPair.getPrivate(), DEFAULT_KEYSTORE_PASSWORD, certChain);
         } catch (KeyStoreException e) {
             LOGGER.atError("Unable to store generated cert", e);
@@ -175,7 +176,7 @@ public class MQTTClientKeyStore {
             SSLContext sc = SSLContext.getInstance("TLS");
             sc.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
             return sc.getSocketFactory();
-        } catch (NoSuchAlgorithmException | KeyStoreException | UnrecoverableKeyException | KeyManagementException e) {
+        } catch (NoSuchAlgorithmException | UnrecoverableKeyException | KeyManagementException e) {
             throw new KeyStoreException("Unable to create SocketFactory from KeyStore", e);
         }
     }

--- a/src/main/java/com/aws/greengrass/mqttbridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/clients/MQTTClient.java
@@ -38,7 +38,6 @@ public class MQTTClient implements MessageClient {
     private static final int MIN_WAIT_RETRY_IN_SECONDS = 1;
     private static final int MAX_WAIT_RETRY_IN_SECONDS = 120;
 
-    private final MqttConnectOptions connOpts = new MqttConnectOptions();
     private Consumer<Message> messageHandler;
     private final URI brokerUri;
     private final String clientId;
@@ -231,17 +230,21 @@ public class MQTTClient implements MessageClient {
         });
     }
 
-    private synchronized void connectAndSubscribe() throws KeyStoreException {
-        if (connectFuture != null) {
-            connectFuture.cancel(true);
-        }
-
-        //TODO: persistent session could be used
+    private MqttConnectOptions getConnectionOptions() throws KeyStoreException {
+        MqttConnectOptions connOpts = new MqttConnectOptions();
         connOpts.setCleanSession(true);
 
         if ("ssl".equalsIgnoreCase(brokerUri.getScheme())) {
             SSLSocketFactory ssf = mqttClientKeyStore.getSSLSocketFactory();
             connOpts.setSocketFactory(ssf);
+        }
+
+        return connOpts;
+    }
+
+    private synchronized void connectAndSubscribe() throws KeyStoreException {
+        if (connectFuture != null) {
+            connectFuture.cancel(true);
         }
 
         LOGGER.atInfo()
@@ -252,9 +255,9 @@ public class MQTTClient implements MessageClient {
         connectFuture = executorService.submit(this::reconnectAndResubscribe);
     }
 
-    private synchronized void doConnect() throws MqttException {
+    private synchronized void doConnect() throws MqttException, KeyStoreException {
         if (!mqttClientInternal.isConnected()) {
-            mqttClientInternal.connect(connOpts);
+            mqttClientInternal.connect(getConnectionOptions());
             LOGGER.atInfo()
                     .kv(BridgeConfig.KEY_BROKER_URI, brokerUri)
                     .kv(BridgeConfig.KEY_CLIENT_ID, clientId)
@@ -269,7 +272,7 @@ public class MQTTClient implements MessageClient {
             try {
                 // TODO: Clean up this loop
                 doConnect();
-            } catch (MqttException e) {
+            } catch (MqttException | KeyStoreException e) {
                 LOGGER.atDebug().setCause(e)
                         .log("Unable to connect. Will be retried after {} seconds", waitBeforeRetry);
                 try {

--- a/src/main/java/com/aws/greengrass/mqttbridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/clients/MQTTClient.java
@@ -104,7 +104,7 @@ public class MQTTClient implements MessageClient {
         this.mqttClientInternal = mqttClient;
         this.dataStore = new MemoryPersistence();
         this.mqttClientKeyStore = mqttClientKeyStore;
-        this.mqttClientKeyStore.listenToUpdates(this::reset);
+        this.mqttClientKeyStore.listenToCAUpdates(this::reset);
         this.executorService = executorService;
     }
 

--- a/src/test/java/com/aws/greengrass/mqttbridge/auth/MQTTClientKeyStoreTest.java
+++ b/src/test/java/com/aws/greengrass/mqttbridge/auth/MQTTClientKeyStoreTest.java
@@ -67,11 +67,9 @@ public class MQTTClientKeyStoreTest {
     private CertificateManager mockCertificateManager;
 
     @Test
-    void GIVEN_MQTTClientKeyStore_WHEN_initialized_THEN_key_and_cert_generated() throws Exception {
+    void GIVEN_MQTTClientKeyStore_WHEN_initialized_THEN_keyAndCertGenerated() throws Exception {
         MQTTClientKeyStore mqttClientKeyStore = new MQTTClientKeyStore(mockCertificateManager);
         mqttClientKeyStore.init();
-        CountDownLatch updateLatch = new CountDownLatch(1);
-        mqttClientKeyStore.listenToUpdates(updateLatch::countDown);
 
         ArgumentCaptor<Consumer<X509Certificate[]>> cbArgumentCaptor = ArgumentCaptor.forClass(Consumer.class);
         verify(mockCertificateManager, times(1))
@@ -84,7 +82,6 @@ public class MQTTClientKeyStoreTest {
         X509Certificate certificate = pemToX509Certificate(CERTIFICATE);
         X509Certificate[] chain = {certificate, certificate};
         certCallback.accept(chain);
-        assertThat(updateLatch.await(100, TimeUnit.MILLISECONDS), is(true));
         assertThat(keyStore.size(), is(1));
 
         PrivateKey privateKey = (PrivateKey) keyStore.getKey(KEY_ALIAS, DEFAULT_KEYSTORE_PASSWORD);
@@ -106,7 +103,7 @@ public class MQTTClientKeyStoreTest {
         MQTTClientKeyStore mqttClientKeyStore = new MQTTClientKeyStore(mockCertificateManager);
         mqttClientKeyStore.init();
         CountDownLatch updateLatch = new CountDownLatch(1);
-        mqttClientKeyStore.listenToUpdates(updateLatch::countDown);
+        mqttClientKeyStore.listenToCAUpdates(updateLatch::countDown);
 
         KeyStore keyStore = mqttClientKeyStore.getKeyStore();
         assertThat(keyStore.size(), is(0));
@@ -122,11 +119,11 @@ public class MQTTClientKeyStoreTest {
     }
 
     @Test
-    void GIVEN_MQTTClientKeyStore_WHEN_called_getSSLSocketFactory_THEN_returns_SSLSocketFactory() throws Exception {
+    void GIVEN_MQTTClientKeyStore_WHEN_getSSLSocketFactory_THEN_returns_SSLSocketFactory() throws Exception {
         MQTTClientKeyStore mqttClientKeyStore = new MQTTClientKeyStore(mockCertificateManager);
         mqttClientKeyStore.init();
-        CountDownLatch updateLatch = new CountDownLatch(2);
-        mqttClientKeyStore.listenToUpdates(updateLatch::countDown);
+        CountDownLatch updateLatch = new CountDownLatch(1);
+        mqttClientKeyStore.listenToCAUpdates(updateLatch::countDown);
 
         ArgumentCaptor<Consumer<X509Certificate[]>> cbArgumentCaptor = ArgumentCaptor.forClass(Consumer.class);
         verify(mockCertificateManager, times(1))

--- a/src/test/java/com/aws/greengrass/mqttbridge/auth/MQTTClientKeyStoreTest.java
+++ b/src/test/java/com/aws/greengrass/mqttbridge/auth/MQTTClientKeyStoreTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class MQTTClientKeyStoreTest {
-    public static final String CERTIFICATE = "-----BEGIN CERTIFICATE-----\r\n"
+    private static final String CERTIFICATE = "-----BEGIN CERTIFICATE-----\r\n"
             + "MIICujCCAaICCQCQcEEQmGoJqjANBgkqhkiG9w0BAQUFADAfMR0wGwYDVQQDDBRt\r\n"
             + "b3F1ZXR0ZS5lY2xpcHNlLm9yZzAeFw0yMDA3MjExODA2MzdaFw0yMTA3MTYxODA2\r\n"
             + "MzdaMB8xHTAbBgNVBAMMFG1vcXVldHRlLmVjbGlwc2Uub3JnMIIBIjANBgkqhkiG\r\n"


### PR DESCRIPTION
It is not necessary to disconnect the MQTT Bridge when the client
certificate rotates. This change removes that logic, but still ensures
that the new client certificate is used the next time the bridge
connects.

CA rotation still results in a disconnect, as that indicates that the
client should no longer trust the server.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
