### PR TITLE
Added `targetTopicPrefix`

### DIFF
--- a/src/main/java/com/aws/greengrass/mqttbridge/TopicMapping.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/TopicMapping.java
@@ -46,6 +46,46 @@ public class TopicMapping {
         private TopicType source;
         @Getter
         private TopicType target;
+        private String targetTopicPrefix;
+
+        /**
+         * Get the configured target-topic.
+         * 
+         * <p>Hard-coded to fit the legacy implementation where target-topic wasn't 
+         * configurable. This was represented by an empty string.</p>
+         *
+         * @return configured target topic
+         */
+        public String getTargetTopic() {
+            return "";
+        }
+
+        /**
+         * Get the configured target-topic-prefix.
+         *
+         * @return configured target-topic-prefix
+         */
+        public String getTargetTopicPrefix() {
+            if (targetTopicPrefix == null) {
+                return "";
+            } else {
+                return targetTopicPrefix;
+            }
+        }
+
+        /**
+         * Create MappingEntry with no `targetTopicPrefix`.
+         * 
+         * @param topic the source-topic to map from
+         * @param source the source integration to listen on
+         * @param target the target integration to bridge to
+         */
+        MappingEntry(String topic, TopicType source, TopicType target) {
+            this.topic = topic;
+            this.source = source;
+            this.target = target;
+            this.targetTopicPrefix = "";
+        }
 
         @Override
         public String toString() {

--- a/src/test/java/com/aws/greengrass/mqttbridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqttbridge/MQTTBridgeTest.java
@@ -226,7 +226,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         startKernelWithConfig("config_with_mapping.yaml");
         TopicMapping topicMapping = ((MQTTBridge) kernel.locate(MQTTBridge.SERVICE_NAME)).getTopicMapping();
 
-        assertThat(() -> topicMapping.getMapping().size(), EventuallyLambdaMatcher.eventuallyEval(is(3)));
+        assertThat(() -> topicMapping.getMapping().size(), EventuallyLambdaMatcher.eventuallyEval(is(5)));
         Map<String, TopicMapping.MappingEntry> expectedMapping = new HashMap<>();
         expectedMapping.put("mapping1",
                 new TopicMapping.MappingEntry("topic/to/map/from/local/to/cloud", TopicMapping.TopicType.LocalMqtt,
@@ -237,6 +237,12 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         expectedMapping.put("mapping3",
                 new TopicMapping.MappingEntry("topic/to/map/from/local/to/cloud/2", TopicMapping.TopicType.LocalMqtt,
                         TopicMapping.TopicType.IotCore));
+        expectedMapping.put("mapping4",
+                new TopicMapping.MappingEntry("topic/to/map/from/local/to/pubsub/2", TopicMapping.TopicType.LocalMqtt,
+                        TopicMapping.TopicType.Pubsub, "a-prefix"));
+        expectedMapping.put("mapping5",
+                new TopicMapping.MappingEntry("topic/to/map/from/local/to/cloud/3", TopicMapping.TopicType.LocalMqtt,
+                        TopicMapping.TopicType.IotCore, "a-prefix"));
 
         assertEquals(expectedMapping, topicMapping.getMapping());
     }
@@ -263,7 +269,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         startKernelWithConfig("config_with_mapping.yaml");
         TopicMapping topicMapping = ((MQTTBridge) kernel.locate(MQTTBridge.SERVICE_NAME)).getTopicMapping();
 
-        assertThat(() -> topicMapping.getMapping().size(), EventuallyLambdaMatcher.eventuallyEval(is(3)));
+        assertThat(() -> topicMapping.getMapping().size(), EventuallyLambdaMatcher.eventuallyEval(is(5)));
         kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
                 .lookupTopics(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_MQTT_TOPIC_MAPPING)
                 .replaceAndWait(Collections.EMPTY_MAP);

--- a/src/test/resources/com/aws/greengrass/mqttbridge/config_with_mapping.yaml
+++ b/src/test/resources/com/aws/greengrass/mqttbridge/config_with_mapping.yaml
@@ -15,6 +15,16 @@ services:
           topic: topic/to/map/from/local/to/cloud/2
           source: LocalMqtt
           target: IotCore
+        mapping4:
+          topic: topic/to/map/from/local/to/pubsub/2
+          source: LocalMqtt
+          target: Pubsub
+          targetTopicPrefix: a-prefix
+        mapping5:
+          topic: topic/to/map/from/local/to/cloud/3
+          source: LocalMqtt
+          target: IotCore
+          targetTopicPrefix: a-prefix
   main:
     dependencies:
       - aws.greengrass.clientdevices.mqtt.Bridge


### PR DESCRIPTION
**Issue #, if available:**
GH-68

**Description of changes:**
Added a new configuration option named `targetTopicPrefix`. This configuration option will add a prefix to the target topic before sending the message to the target integration.

**Why is this change necessary:**
This allows for managing IPC topics separate from MQTT topics.

**How was this change tested:**
`mvn clean verify`

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
