### PR TITLE
chore: migrate to subscribeToCertificateUpdates API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,26 +43,26 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>client-devices-auth</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.2.0-SNAPSHOT</version>
+            <version>2.6.0-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.aws.greengrass</groupId>
+            <artifactId>nucleus</artifactId>
+            <version>2.6.0-SNAPSHOT</version>
+            <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
             <version>[1.2.5,)</version>
-        </dependency>
-        <dependency>
-            <groupId>com.aws.greengrass</groupId>
-            <artifactId>nucleus</artifactId>
-            <version>2.2.0-SNAPSHOT</version>
-            <type>test-jar</type>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -75,21 +75,6 @@
             <artifactId>moquette-broker</artifactId>
             <version>0.12.1</version>
             <scope>test</scope>
-        </dependency>
-        <!-- This dependency is also shadowed in Nucleus because I import moquette for testing.
-        Have to import it explicitly here-->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- This dependency is also shadowed in Nucleus because I import moquette for testing.
-        Have to import it explicitly here-->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.11.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/recipe.json
+++ b/recipe.json
@@ -7,7 +7,7 @@
   "ComponentPublisher": "{COMPONENT_PUBLISHER}",
   "ComponentDependencies": {
     "aws.greengrass.clientdevices.Auth": {
-      "VersionRequirement": ">=2.0.0 <2.2.0",
+      "VersionRequirement": ">=2.2.0 <2.3.0",
       "DependencyType": "HARD"
     }
   },

--- a/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
@@ -6,7 +6,6 @@
 package com.aws.greengrass.mqttbridge;
 
 import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
-import com.aws.greengrass.certificatemanager.certificate.CsrProcessingException;
 import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Node;
 import com.aws.greengrass.config.Topics;
@@ -14,10 +13,10 @@ import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.ImplementsService;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.device.ClientDevicesAuthService;
+import com.aws.greengrass.device.exception.CertificateGenerationException;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
-import com.aws.greengrass.mqttbridge.auth.CsrGeneratingException;
 import com.aws.greengrass.mqttbridge.auth.MQTTClientKeyStore;
 import com.aws.greengrass.mqttbridge.clients.IoTCoreClient;
 import com.aws.greengrass.mqttbridge.clients.MQTTClient;
@@ -116,7 +115,7 @@ public class MQTTBridge extends PluginService {
     public void startup() {
         try {
             mqttClientKeyStore.init();
-        } catch (CsrProcessingException | KeyStoreException | CsrGeneratingException e) {
+        } catch (KeyStoreException | CertificateGenerationException e) {
             serviceErrored(e);
             return;
         }

--- a/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqttbridge/MQTTBridge.java
@@ -162,6 +162,8 @@ public class MQTTBridge extends PluginService {
 
     @Override
     public void shutdown() {
+        mqttClientKeyStore.shutdown();
+
         messageBridge.removeMessageClient(TopicMapping.TopicType.LocalMqtt);
         if (mqttClient != null) {
             mqttClient.stop();

--- a/src/test/java/com/aws/greengrass/mqttbridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqttbridge/MQTTBridgeTest.java
@@ -86,6 +86,9 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
 
     @BeforeEach
     void setup() throws IOException {
+        // Set this property for kernel to scan its own classpath to find plugins
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
+
         kernel = new Kernel();
         kernel.getContext().put(CertificateManager.class, mockCertificateManager);
         IConfig defaultConfig = new MemoryConfig(new Properties());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Removes CSR generation logic for getting client certificates and instead uses the subscribeToCertificateUpdates API

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**
Depends on https://github.com/aws-greengrass/aws-greengrass-client-device-auth/pull/95
CI will fail until the above is merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
