### PR TITLE
chore: debug when async subscriptions complete

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClient.java
@@ -213,7 +213,7 @@ public class IoTCoreClient implements MessageClient {
             }
         }
 
-        LOGGER.atDebug().kv("subscribedIotCoreTopics", String.join(",", subscribedIotCoreTopics))
+        LOGGER.atTrace().kv("subscribedIotCoreTopics", String.join(",", subscribedIotCoreTopics))
                 .log("Subscription requests complete");
     }
 

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClient.java
@@ -213,7 +213,7 @@ public class IoTCoreClient implements MessageClient {
             }
         }
 
-        LOGGER.atTrace().kv("subscribedIotCoreTopics", String.join(",", subscribedIotCoreTopics))
+        LOGGER.atTrace().kv("subscribedIotCoreTopics", subscribedIotCoreTopics)
                 .log("Subscription requests complete");
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

* Adds a debug log after subscriptions to IoTCore have been made.
* Ensure subscription method exits immediately on interrupt

**Why is this change necessary:**

To aid in debugging,  currently we debug log when we _start_ updating subscriptions, but not when the actual operation has completed. 

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
