### PR TITLE
fix: retry IotCoreClient subscriptions when greengrass starts offline

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClient.java
@@ -190,7 +190,8 @@ public class IoTCoreClient implements MessageClient {
                 RetryUtils.runWithRetry(subscribeRetryConfig, () -> {
                     try {
                         // retry only if client is connected; skip if offline.
-                        // topics left here should be subscribed when the client is back online (onConnectionResumed event)
+                        // topics left here should be subscribed when the client
+                        // is back online (onConnectionResumed event)
                         if (iotMqttClient.connected()) {
                             subscribeToIotCore(topic);
                             subscribedIotCoreTopics.add(topic);

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClient.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import javax.inject.Inject;
 
@@ -46,7 +45,6 @@ public class IoTCoreClient implements MessageClient {
     @Getter(AccessLevel.PROTECTED)
     private Set<String> toSubscribeIotCoreTopics = new HashSet<>();
     private volatile Consumer<Message> messageHandler;
-    @Getter(AccessLevel.PACKAGE) // for unit testing
     private Future<?> subscribeFuture;
     private final Object subscribeLock = new Object();
     private final MqttClient iotMqttClient;

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
@@ -34,6 +34,7 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -73,6 +74,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
+@Disabled
 public class MQTTBridgeTest extends GGServiceTestUtil {
     private static final long TEST_TIME_OUT_SEC = 30L;
 

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
@@ -34,7 +34,6 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -74,7 +73,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-@Disabled
 public class MQTTBridgeTest extends GGServiceTestUtil {
     private static final long TEST_TIME_OUT_SEC = 30L;
 

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClientTest.java
@@ -31,7 +31,9 @@ import java.util.stream.Collectors;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -77,7 +79,7 @@ public class IoTCoreClientTest {
     }
 
     @Test
-    void GIVEN_offline_iotcore_client_WHEN_update_subscriptions_THEN_subscribe_once_online() {
+    void GIVEN_offline_iotcore_client_WHEN_update_subscriptions_THEN_subscribe_once_online() throws Exception {
         reset(mockIotMqttClient);
 
         IoTCoreClient iotCoreClient = new IoTCoreClient(mockIotMqttClient, executorService);
@@ -92,6 +94,7 @@ public class IoTCoreClientTest {
         });
 
         // verify no subscriptions were made
+        verify(mockIotMqttClient, never()).subscribe(any(SubscribeRequest.class));
         assertThat(iotCoreClient.getSubscribedIotCoreTopics().size(), is(0));
         assertThat(iotCoreClient.getToSubscribeIotCoreTopics(),
                 Matchers.containsInAnyOrder("iotcore/topic", "iotcore/topic2"));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

* Adjust the behavior of `IotCoreClient` so that subscriptions are retried in the event greengrass was started offline.
* Return early if interrupted in `IotCoreClient#subscribeToTopicsWithRetry`

**Why is this change necessary:**

Customers may start greengrass while offline so we must handle that scenario in `IotCoreClient`

**How was this change tested:**

Unit test and UAT

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
