### PR TITLE
feat: mqtt5 config flag

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -45,14 +45,6 @@ public final class BridgeConfig {
     private final String clientId;
     private final Map<String, TopicMapping.MappingEntry> topicMapping;
 
-    /**
-     * Create a BridgeConfig from configuration topics.
-     *
-     * @param configurationTopics configuration topics
-     * @return bridge config
-     * @throws InvalidConfigurationException if config from topics is invalid
-     */
-    @SuppressWarnings("PMD.PrematureDeclaration")
     public static BridgeConfig fromTopics(Topics configurationTopics) throws InvalidConfigurationException {
         URI brokerUri;
         try {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.mqtt.bridge;
 
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.mqtt.bridge.model.InvalidConfigurationException;
+import com.aws.greengrass.mqtt.bridge.model.MqttVersion;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -37,13 +38,17 @@ public final class BridgeConfig {
     public static final String KEY_BROKER_URI = "brokerUri";
     public static final String KEY_CLIENT_ID = "clientId";
     static final String KEY_MQTT_TOPIC_MAPPING = "mqttTopicMapping";
+    static final String KEY_BROKER_CLIENT = "brokerClient";
+    static final String KEY_VERSION = "version";
 
     private static final String DEFAULT_BROKER_URI = "ssl://localhost:8883";
     private static final String DEFAULT_CLIENT_ID = "mqtt-bridge-" + Utils.generateRandomString(11);
+    private static final String DEFAULT_MQTT_VERSION = MqttVersion.MQTT3.getName();
 
     private final URI brokerUri;
     private final String clientId;
     private final Map<String, TopicMapping.MappingEntry> topicMapping;
+    private final MqttVersion mqttVersion;
 
     /**
      * Create a BridgeConfig from configuration topics.
@@ -54,44 +59,64 @@ public final class BridgeConfig {
      */
     @SuppressWarnings("PMD.PrematureDeclaration")
     public static BridgeConfig fromTopics(Topics configurationTopics) throws InvalidConfigurationException {
-        URI brokerUri;
-        try {
-            brokerUri = getBrokerUri(configurationTopics);
-        } catch (URISyntaxException e) {
-            throw new InvalidConfigurationException("Malformed brokerUri", e);
-        }
-        String clientId = getClientId(configurationTopics);
-        Map<String, TopicMapping.MappingEntry> topicMapping;
-        try {
-            topicMapping = getTopicMapping(configurationTopics);
-        } catch (IllegalArgumentException e) {
-            throw new InvalidConfigurationException("Malformed mqttTopicMapping", e);
-        }
-        return new BridgeConfig(brokerUri, clientId, topicMapping);
+        return new BridgeConfig(
+                getBrokerUri(configurationTopics),
+                getClientId(configurationTopics),
+                getTopicMapping(configurationTopics),
+                getMqttVersion(configurationTopics)
+        );
     }
 
-    private static URI getBrokerUri(Topics configurationTopics) throws URISyntaxException {
+    private static URI getBrokerUri(Topics configurationTopics) throws InvalidConfigurationException {
         // brokerUri takes precedence since brokerServerUri is deprecated
         String brokerServerUri = Coerce.toString(
                 configurationTopics.findOrDefault(DEFAULT_BROKER_URI, KEY_BROKER_SERVER_URI));
         String brokerUri = Coerce.toString(
                 configurationTopics.findOrDefault(brokerServerUri, KEY_BROKER_URI));
-        return new URI(brokerUri);
+        try {
+            return new URI(brokerUri);
+        } catch (URISyntaxException e) {
+            throw new InvalidConfigurationException("Malformed " + KEY_BROKER_URI + ": " + brokerUri, e);
+        }
     }
 
-    private static String getClientId(Topics topics) {
-        return Coerce.toString(topics.findOrDefault(DEFAULT_CLIENT_ID, KEY_CLIENT_ID));
+    private static String getClientId(Topics configurationTopics) {
+        return Coerce.toString(configurationTopics.findOrDefault(DEFAULT_CLIENT_ID, KEY_CLIENT_ID));
     }
 
-    private static Map<String, TopicMapping.MappingEntry> getTopicMapping(Topics configurationTopics) {
-        return OBJECT_MAPPER.convertValue(
-                configurationTopics.lookupTopics(KEY_MQTT_TOPIC_MAPPING).toPOJO(),
-                new TypeReference<Map<String, TopicMapping.MappingEntry>>() {
-                });
+    private static Map<String, TopicMapping.MappingEntry> getTopicMapping(Topics configurationTopics)
+            throws InvalidConfigurationException {
+        try {
+            return OBJECT_MAPPER.convertValue(
+                    configurationTopics.lookupTopics(KEY_MQTT_TOPIC_MAPPING).toPOJO(),
+                    new TypeReference<Map<String, TopicMapping.MappingEntry>>() {
+                    });
+        } catch (IllegalArgumentException e) {
+            throw new InvalidConfigurationException("Malformed " + KEY_MQTT_TOPIC_MAPPING, e);
+        }
     }
 
+    private static MqttVersion getMqttVersion(Topics configurationTopics) throws InvalidConfigurationException {
+        String versionName = Coerce.toString(configurationTopics.findOrDefault(
+                DEFAULT_MQTT_VERSION,
+                KEY_BROKER_CLIENT, KEY_VERSION));
+        MqttVersion version = MqttVersion.fromName(versionName);
+        if (version == null) {
+            throw new InvalidConfigurationException(
+                    "Unsupported value for " + KEY_BROKER_CLIENT + "." + KEY_VERSION + ": " + versionName);
+        }
+        return version;
+    }
+
+    /**
+     * Determine if the component needs to be reinstalled, based on configuration change.
+     *
+     * @param newConfig new configuration
+     * @return true if the component should be reinstalled
+     */
     public boolean reinstallRequired(BridgeConfig newConfig) {
         return !Objects.equals(getBrokerUri(), newConfig.getBrokerUri())
-                || !Objects.equals(getClientId(), newConfig.getClientId());
+                || !Objects.equals(getClientId(), newConfig.getClientId())
+                || !Objects.equals(getMqttVersion(), newConfig.getMqttVersion());
     }
 }

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -45,6 +45,14 @@ public final class BridgeConfig {
     private final String clientId;
     private final Map<String, TopicMapping.MappingEntry> topicMapping;
 
+    /**
+     * Create a BridgeConfig from configuration topics.
+     *
+     * @param configurationTopics configuration topics
+     * @return bridge config
+     * @throws InvalidConfigurationException if config from topics is invalid
+     */
+    @SuppressWarnings("PMD.PrematureDeclaration")
     public static BridgeConfig fromTopics(Topics configurationTopics) throws InvalidConfigurationException {
         URI brokerUri;
         try {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/model/MqttVersion.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/model/MqttVersion.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqtt.bridge.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import java.util.Arrays;
+
+@ToString
+@RequiredArgsConstructor
+public enum MqttVersion {
+
+    MQTT5("mqtt5"),
+    MQTT3("mqtt3");
+
+    @Getter
+    private final String name;
+
+    /**
+     * Get an MqttVersion from its name.
+     *
+     * @param name mqtt version string
+     * @return mqtt version
+     */
+    public static MqttVersion fromName(String name) {
+        return Arrays.stream(MqttVersion.values())
+                .filter(v -> v.getName().equalsIgnoreCase(name))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -9,6 +9,7 @@ import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.mqtt.bridge.model.InvalidConfigurationException;
+import com.aws.greengrass.mqtt.bridge.model.MqttVersion;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.Utils;
 import org.junit.jupiter.api.AfterEach;
@@ -31,6 +32,7 @@ class BridgeConfigTest {
 
     private static final String DEFAULT_BROKER_URI = "ssl://localhost:8883";
     private static final String DEFAULT_CLIENT_ID_PREFIX = "mqtt-bridge-";
+    private static final String DEFAULT_MQTT_VERSION = "mqtt3";
     private static final String BROKER_URI = "tcp://localhost:8883";
     private static final String BROKER_SERVER_URI = "tcp://localhost:8884";
     private static final String MALFORMED_BROKER_URI = "tcp://ma]formed.uri:8883";
@@ -54,12 +56,12 @@ class BridgeConfigTest {
         BridgeConfig expectedConfig = new BridgeConfig(
                 URI.create(DEFAULT_BROKER_URI),
                 config.getClientId(),
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                MqttVersion.fromName(DEFAULT_MQTT_VERSION)
         );
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
     }
-
 
     @Test
     void GIVEN_brokerUri_config_WHEN_bridge_config_created_THEN_uri_set() throws InvalidConfigurationException {
@@ -69,7 +71,8 @@ class BridgeConfigTest {
         BridgeConfig expectedConfig = new BridgeConfig(
                 URI.create(BROKER_URI),
                 config.getClientId(),
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                MqttVersion.fromName(DEFAULT_MQTT_VERSION)
         );
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -84,7 +87,8 @@ class BridgeConfigTest {
         BridgeConfig expectedConfig = new BridgeConfig(
                 URI.create(BROKER_URI),
                 config.getClientId(),
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                MqttVersion.fromName(DEFAULT_MQTT_VERSION)
         );
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -98,7 +102,8 @@ class BridgeConfigTest {
         BridgeConfig expectedConfig = new BridgeConfig(
                 URI.create(BROKER_SERVER_URI),
                 config.getClientId(),
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                MqttVersion.fromName(DEFAULT_MQTT_VERSION)
         );
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -118,7 +123,8 @@ class BridgeConfigTest {
         BridgeConfig expectedConfig = new BridgeConfig(
                 URI.create(DEFAULT_BROKER_URI),
                 CLIENT_ID,
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                MqttVersion.fromName(DEFAULT_MQTT_VERSION)
         );
         assertEquals(expectedConfig, config);
     }
@@ -143,7 +149,8 @@ class BridgeConfigTest {
         BridgeConfig expectedConfig = new BridgeConfig(
                 URI.create(DEFAULT_BROKER_URI),
                 config.getClientId(),
-                expectedEntries
+                expectedEntries,
+                MqttVersion.fromName(DEFAULT_MQTT_VERSION)
         );
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -162,6 +169,27 @@ class BridgeConfigTest {
                         "m3",
                         Utils.immutableMap("topic", "mqtt/topic3", "source", TopicMapping.TopicType.LocalMqtt.toString(), "target", TopicMapping.TopicType.IotCore.toString())));
 
+        assertThrows(InvalidConfigurationException.class, () -> BridgeConfig.fromTopics(topics));
+    }
+
+    @Test
+    void GIVEN_mqtt_version_config_WHEN_bridge_config_created_THEN_version_set() throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_VERSION).dflt("mqtt5");
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = new BridgeConfig(
+                URI.create(DEFAULT_BROKER_URI),
+                config.getClientId(),
+                Collections.emptyMap(),
+                MqttVersion.fromName("mqtt5")
+        );
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @Test
+    void GIVEN_invalid_mqtt_version_config_WHEN_bridge_config_created_THEN_exception_thrown() {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_VERSION).dflt("INVALID_VALUE");
         assertThrows(InvalidConfigurationException.class, () -> BridgeConfig.fromTopics(topics));
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Adds a `configuration.brokerClient.version` config.  Possible values are `mqtt3` and `mqtt5` with a default of `mqtt3`.  This config will control which local mqtt client is used (v3 or v5).  If this property changes, bridge will be reinstalled.

**Why is this change necessary:**
To support configurable mqtt3/mqtt5 within bridge

**How was this change tested:**
unit tests
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
