### PR TITLE
feat: local mqtt client factory

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClient.java
@@ -100,12 +100,14 @@ public class IoTCoreClient implements MessageClient {
     /**
      * Start the {@link IoTCoreClient}.
      */
+    @Override
     public void start() {
     }
 
     /**
      * Stop the {@link IoTCoreClient}.
      */
+    @Override
     public void stop() {
         removeMappingAndSubscriptions();
     }

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqtt.bridge.clients;
+
+
+import com.aws.greengrass.mqtt.bridge.BridgeConfig;
+import com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore;
+import lombok.Setter;
+
+import java.util.concurrent.ExecutorService;
+import javax.inject.Inject;
+
+public class LocalMqttClientFactory {
+
+    private final MQTTClientKeyStore mqttClientKeyStore;
+    private final ExecutorService executorService;
+
+    @Setter
+    private BridgeConfig config;
+
+    @Inject
+    public LocalMqttClientFactory(MQTTClientKeyStore mqttClientKeyStore,
+                                  ExecutorService executorService) {
+        this.mqttClientKeyStore = mqttClientKeyStore;
+        this.executorService = executorService;
+    }
+
+    /**
+     * Create a local mqtt client.
+     *
+     * @return local mqtt client
+     * @throws MQTTClientException if unable to create client
+     */
+    public MessageClient createLocalMqttClient() throws MQTTClientException {
+        checkConfig();
+        switch (config.getMqttVersion()) {
+            case MQTT5:
+                // TODO
+            case MQTT3: // fall-through
+            default:
+                return new MQTTClient(config.getBrokerUri(), config.getClientId(),
+                        mqttClientKeyStore, executorService);
+        }
+    }
+
+    private void checkConfig() {
+        if (config == null) {
+            throw new IllegalStateException("config is missing, ensure setConfig() is called");
+        }
+    }
+}

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
@@ -140,6 +140,7 @@ public class MQTTClient implements MessageClient {
      *
      * @throws RuntimeException if the client cannot load the KeyStore used to connect to the broker.
      */
+    @Override
     public void start() {
         mqttClientInternal.setCallback(mqttCallback);
         try {
@@ -152,6 +153,7 @@ public class MQTTClient implements MessageClient {
     /**
      * Stop the {@link MQTTClient}.
      */
+    @Override
     public void stop() {
         removeMappingAndSubscriptions();
 

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MessageClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MessageClient.java
@@ -34,4 +34,8 @@ public interface MessageClient {
      * @return true if supported
      */
     boolean supportsTopicFilters();
+
+    void start();
+
+    void stop();
 }

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/PubSubClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/PubSubClient.java
@@ -56,12 +56,14 @@ public class PubSubClient implements MessageClient {
     /**
      * Start the {@link PubSubClient}.
      */
+    @Override
     public void start() {
     }
 
     /**
      * Stop the {@link PubSubClient}.
      */
+    @Override
     public void stop() {
         removeMappingAndSubscriptions();
     }

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore;
 import com.aws.greengrass.mqtt.bridge.clients.IoTCoreClient;
+import com.aws.greengrass.mqtt.bridge.clients.LocalMqttClientFactory;
 import com.aws.greengrass.mqtt.bridge.clients.MQTTClient;
 import com.aws.greengrass.mqtt.bridge.clients.PubSubClient;
 import com.aws.greengrass.mqttclient.MqttClient;
@@ -345,6 +346,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         Kernel mockKernel = mock(Kernel.class);
         MQTTClientKeyStore mockMqttClientKeyStore = mock(MQTTClientKeyStore.class);
         MQTTBridge mqttBridge;
+        LocalMqttClientFactory localMqttClientFactory = new LocalMqttClientFactory(mockMqttClientKeyStore, ses);
 
         Topics config = Topics.of(context, KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null);
         config.lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_BROKER_URI)
@@ -352,10 +354,12 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         config.lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_CLIENT_ID)
                 .dflt(MQTTBridge.SERVICE_NAME);
 
+        localMqttClientFactory.setConfig(BridgeConfig.fromTopics(config));
+
         try (MqttClient mockIotMqttClient = mock(MqttClient.class)) {
             mqttBridge =
                     new MQTTBridge(config, mockTopicMapping, mockMessageBridge, mockPubSubIPCAgent, mockIotMqttClient,
-                            mockKernel, mockMqttClientKeyStore, ses);
+                            mockKernel, mockMqttClientKeyStore, localMqttClientFactory, ses);
         }
 
         ClientDevicesAuthService mockClientAuthService = mock(ClientDevicesAuthService.class);
@@ -395,6 +399,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         MessageBridge mockMessageBridge = mock(MessageBridge.class);
         Kernel mockKernel = mock(Kernel.class);
         MQTTClientKeyStore mockMqttClientKeyStore = mock(MQTTClientKeyStore.class);
+        LocalMqttClientFactory localMqttClientFactory = new LocalMqttClientFactory(mockMqttClientKeyStore, ses);
 
         Topics config = Topics.of(context, KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null);
         config.lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_BROKER_URI)
@@ -402,9 +407,11 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         config.lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_CLIENT_ID)
                 .dflt(MQTTBridge.SERVICE_NAME);
 
+        localMqttClientFactory.setConfig(BridgeConfig.fromTopics(config));
+
         MQTTBridge mqttBridge =
                 new MQTTBridge(config, mockTopicMapping, mockMessageBridge, mock(PubSubIPCEventStreamAgent.class),
-                        mock(MqttClient.class), mockKernel, mockMqttClientKeyStore, ses);
+                        mock(MqttClient.class), mockKernel, mockMqttClientKeyStore, localMqttClientFactory, ses);
 
         ClientDevicesAuthService mockClientAuthService = mock(ClientDevicesAuthService.class);
         when(mockKernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME))


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Adds a `LocalMqttClientFactory`, to allow bridge to choose between mqtt3 and 5 clients, based on configuration.

**Why is this change necessary:**

To support v3 and v5 local mqtt clients

**How was this change tested:**
unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
