### PR TITLE
feat: integration test skeleton

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,39 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>add-integration-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/integrationtests/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-integration-test-resource</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>src/integrationtests/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
                 <version>3.13.0</version>

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests;
+
+import com.aws.greengrass.clientdevices.auth.CertificateManager;
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.mqtt.bridge.MQTTBridge;
+import com.aws.greengrass.mqtt.bridge.MQTTBridgeTest;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
+import io.moquette.BrokerConstants;
+import io.moquette.broker.Server;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith({GGExtension.class, UniqueRootPathExtension.class, MockitoExtension.class})
+public class ConfigTest {
+    @TempDir
+    Path rootDir;
+
+    Kernel kernel;
+
+    // TODO mqtt5
+    Server broker;
+
+    // TODO consider executor service or same thread executor
+    ScheduledExecutorService ses;
+
+    @BeforeEach
+    void setup() throws IOException {
+        // Set this property for kernel to scan its own classpath to find plugins
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
+
+        kernel = new Kernel();
+        kernel.getContext().put(CertificateManager.class, mock(CertificateManager.class));
+
+        IConfig defaultConfig = new MemoryConfig(new Properties());
+        defaultConfig.setProperty(BrokerConstants.PORT_PROPERTY_NAME, "8883");
+        broker = new Server();
+        broker.startServer(defaultConfig);
+
+        ses = new ScheduledThreadPoolExecutor(1);
+    }
+
+    @AfterEach
+    void cleanup() {
+        kernel.shutdown();
+        broker.stopServer();
+        ses.shutdownNow();
+    }
+
+    private void startKernelWithConfig(String configFileName) throws InterruptedException {
+        CountDownLatch bridgeRunning = new CountDownLatch(1);
+        kernel.parseArgs("-r", rootDir.toAbsolutePath().toString(), "-i",
+                MQTTBridgeTest.class.getResource(configFileName).toString());
+        GlobalStateChangeListener listener = (GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && service.getState().equals(State.RUNNING)) {
+                bridgeRunning.countDown();
+            }
+        };
+        kernel.getContext().addGlobalStateChangeListener(listener);
+        kernel.launch();
+        assertTrue(bridgeRunning.await(10, TimeUnit.SECONDS));
+    }
+
+    @Test // TODO add other tests
+    void GIVEN_bridge_WHEN_kernel_started_THEN_bridge_starts() throws Exception {
+        startKernelWithConfig("config.yaml");
+    }
+
+}

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests;
+
+import com.aws.greengrass.clientdevices.auth.CertificateManager;
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.mqtt.bridge.MQTTBridge;
+import com.aws.greengrass.mqtt.bridge.MQTTBridgeTest;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
+import io.moquette.BrokerConstants;
+import io.moquette.broker.Server;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith({GGExtension.class, UniqueRootPathExtension.class, MockitoExtension.class})
+public class KeystoreTest {
+
+    @TempDir
+    Path rootDir;
+
+    Kernel kernel;
+
+    // TODO mqtt5
+    Server broker;
+
+    // TODO consider executor service or same thread executor
+    ScheduledExecutorService ses;
+
+    @BeforeEach
+    void setup() throws IOException {
+        // Set this property for kernel to scan its own classpath to find plugins
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
+
+        kernel = new Kernel();
+        kernel.getContext().put(CertificateManager.class, mock(CertificateManager.class));
+
+        IConfig defaultConfig = new MemoryConfig(new Properties());
+        defaultConfig.setProperty(BrokerConstants.PORT_PROPERTY_NAME, "8883");
+        broker = new Server();
+        broker.startServer(defaultConfig);
+
+        ses = new ScheduledThreadPoolExecutor(1);
+    }
+
+    @AfterEach
+    void cleanup() {
+        kernel.shutdown();
+        broker.stopServer();
+        ses.shutdownNow();
+    }
+
+    private void startKernelWithConfig(String configFileName) throws InterruptedException {
+        CountDownLatch bridgeRunning = new CountDownLatch(1);
+        kernel.parseArgs("-r", rootDir.toAbsolutePath().toString(), "-i",
+                MQTTBridgeTest.class.getResource(configFileName).toString());
+        GlobalStateChangeListener listener = (GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && service.getState().equals(State.RUNNING)) {
+                bridgeRunning.countDown();
+            }
+        };
+        kernel.getContext().addGlobalStateChangeListener(listener);
+        kernel.launch();
+        assertTrue(bridgeRunning.await(10, TimeUnit.SECONDS));
+    }
+
+    @Test // TODO add other tests
+    void GIVEN_bridge_WHEN_kernel_started_THEN_bridge_starts() throws Exception {
+        startKernelWithConfig("config.yaml");
+    }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/config.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/config.yaml
@@ -1,0 +1,7 @@
+services:
+    aws.greengrass.clientdevices.mqtt.Bridge:
+        configuration:
+            brokerUri: 'tcp://localhost:8883'
+    main:
+        dependencies:
+            - aws.greengrass.clientdevices.mqtt.Bridge

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/config_with_mapping.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/config_with_mapping.yaml
@@ -1,0 +1,30 @@
+services:
+  aws.greengrass.clientdevices.mqtt.Bridge:
+    configuration:
+      brokerUri: 'tcp://localhost:8883'
+      mqttTopicMapping:
+        mapping1:
+          topic: topic/to/map/from/local/to/cloud
+          source: LocalMqtt
+          target: IotCore
+        mapping2:
+          topic: topic/to/map/from/local/to/pubsub
+          source: LocalMqtt
+          target: Pubsub
+        mapping3:
+          topic: topic/to/map/from/local/to/cloud/2
+          source: LocalMqtt
+          target: IotCore
+        mapping4:
+          topic: topic/to/map/from/local/to/pubsub/2
+          source: LocalMqtt
+          target: Pubsub
+          targetTopicPrefix: a-prefix
+        mapping5:
+          topic: topic/to/map/from/local/to/cloud/3
+          source: LocalMqtt
+          target: IotCore
+          targetTopicPrefix: a-prefix
+  main:
+    dependencies:
+      - aws.greengrass.clientdevices.mqtt.Bridge


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds integration test config to pom.xml and adds empty int test classes.  Follow-up PRs will move over int tests from `MQTTBridgeTest` to here.

**Why is this change necessary:**
Cleaner separation of int tests (currently mixed in unit tests), and to be consistent with other components

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
