### PR TITLE
chore: unsubscribe from TopicMapping updates

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -115,17 +115,17 @@ public class MQTTBridge extends PluginService {
         try {
             localMqttClient = localMqttClientFactory.createLocalMqttClient();
             localMqttClient.start();
-            messageBridge.addOrReplaceMessageClientAndUpdateSubscriptions(
+            messageBridge.registerClient(
                     TopicMapping.TopicType.LocalMqtt, localMqttClient);
         } catch (MQTTClientException e) {
             serviceErrored(e);
             return;
         }
         pubSubClient.start();
-        messageBridge.addOrReplaceMessageClientAndUpdateSubscriptions(TopicMapping.TopicType.Pubsub, pubSubClient);
+        messageBridge.registerClient(TopicMapping.TopicType.Pubsub, pubSubClient);
 
         ioTCoreClient.start();
-        messageBridge.addOrReplaceMessageClientAndUpdateSubscriptions(TopicMapping.TopicType.IotCore, ioTCoreClient);
+        messageBridge.registerClient(TopicMapping.TopicType.IotCore, ioTCoreClient);
 
         messageBridge.start();
         reportState(State.RUNNING);

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -127,6 +127,7 @@ public class MQTTBridge extends PluginService {
         ioTCoreClient.start();
         messageBridge.addOrReplaceMessageClientAndUpdateSubscriptions(TopicMapping.TopicType.IotCore, ioTCoreClient);
 
+        messageBridge.start();
         reportState(State.RUNNING);
     }
 
@@ -135,6 +136,7 @@ public class MQTTBridge extends PluginService {
         certificateAuthorityChangeHandler.stop();
         mqttClientKeyStore.shutdown();
 
+        messageBridge.stop();
         messageBridge.removeMessageClient(TopicMapping.TopicType.LocalMqtt);
         if (localMqttClient != null) {
             localMqttClient.stop();

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MessageBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MessageBridge.java
@@ -70,6 +70,7 @@ public class MessageBridge {
      */
     public void stop() {
         topicMapping.unsubscribeFromUpdates(updateListener);
+        messageClientMap.clear();
     }
 
     /**
@@ -79,10 +80,9 @@ public class MessageBridge {
      *                      MQTTClient
      * @param messageClient client
      */
-    public void addOrReplaceMessageClientAndUpdateSubscriptions(
+    public void registerClient(
             TopicMapping.TopicType clientType, MessageClient messageClient) {
         messageClientMap.put(clientType, messageClient);
-        updateSubscriptionsForClient(clientType, messageClient);
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MessageBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MessageBridge.java
@@ -34,6 +34,7 @@ public class MessageBridge {
     private static final String LOG_KEY_RESOLVED_TARGET_TOPIC = "resolvedTargetTopic";
 
     private final TopicMapping topicMapping;
+    private final TopicMapping.UpdateListener updateListener = this::processMappingAndSubscribe;
     // A map from type of message client to the clients. For example, LocalMqtt -> MQTTClient
     private final Map<TopicMapping.TopicType, MessageClient> messageClientMap = new ConcurrentHashMap<>();
     // A map from type of source to its mapping. The mapping is actually mapping from topic name to its destinations
@@ -50,8 +51,25 @@ public class MessageBridge {
      */
     public MessageBridge(TopicMapping topicMapping) {
         this.topicMapping = topicMapping;
-        this.topicMapping.listenToUpdates(this::processMappingAndSubscribe);
+    }
+
+    /**
+     * Start message bridge.
+     *
+     * <br><br><p>All registered {@link MessageClient}s will have their
+     * subscriptions updated immediately.  Changes to {@link TopicMapping} will
+     * trigger subscription updates as well.
+     */
+    public void start() {
+        topicMapping.listenToUpdates(updateListener);
         processMappingAndSubscribe();
+    }
+
+    /**
+     * Stop the message bridge.
+     */
+    public void stop() {
+        topicMapping.unsubscribeFromUpdates(updateListener);
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/TopicMapping.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/TopicMapping.java
@@ -113,4 +113,8 @@ public class TopicMapping {
     public void listenToUpdates(UpdateListener listener) {
         updateListeners.add(listener);
     }
+
+    public void unsubscribeFromUpdates(UpdateListener listener) {
+        updateListeners.remove(listener);
+    }
 }

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
@@ -574,11 +574,11 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         mqttBridge.startup();
         mqttBridge.shutdown();
 
-        verify(mockMessageBridge).addOrReplaceMessageClientAndUpdateSubscriptions(
+        verify(mockMessageBridge).registerClient(
                 eq(TopicMapping.TopicType.LocalMqtt), any(MQTTClient.class));
-        verify(mockMessageBridge).addOrReplaceMessageClientAndUpdateSubscriptions(
+        verify(mockMessageBridge).registerClient(
                 eq(TopicMapping.TopicType.Pubsub), any(PubSubClient.class));
-        verify(mockMessageBridge).addOrReplaceMessageClientAndUpdateSubscriptions(
+        verify(mockMessageBridge).registerClient(
                 eq(TopicMapping.TopicType.IotCore), any(IoTCoreClient.class));
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Have message bridge unsubscribe from topic mapping changes during shutdown

**Why is this change necessary:**
Ensure clean shutdown

**How was this change tested:**
unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
