### PR TITLE
refactor: move int tests to integrationtests folder

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
@@ -6,38 +6,64 @@
 package com.aws.greengrass.integrationtests;
 
 import com.aws.greengrass.clientdevices.auth.CertificateManager;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.config.UpdateBehaviorTree;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.mqtt.bridge.BridgeConfig;
 import com.aws.greengrass.mqtt.bridge.MQTTBridge;
 import com.aws.greengrass.mqtt.bridge.MQTTBridgeTest;
+import com.aws.greengrass.mqtt.bridge.TopicMapping;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
+import com.aws.greengrass.util.Utils;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.github.grantwest.eventually.EventuallyLambdaMatcher;
 import io.moquette.BrokerConstants;
 import io.moquette.broker.Server;
 import io.moquette.broker.config.IConfig;
 import io.moquette.broker.config.MemoryConfig;
+import org.eclipse.paho.client.mqttv3.MqttException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith({GGExtension.class, UniqueRootPathExtension.class, MockitoExtension.class})
 public class ConfigTest {
+    private static final long TEST_TIME_OUT_SEC = 30L;
+    private static final Supplier<UpdateBehaviorTree> MERGE_UPDATE_BEHAVIOR =
+            () -> new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.MERGE, System.currentTimeMillis());
+
     @TempDir
     Path rootDir;
 
@@ -81,14 +107,208 @@ public class ConfigTest {
                 bridgeRunning.countDown();
             }
         };
-        kernel.getContext().addGlobalStateChangeListener(listener);
-        kernel.launch();
-        assertTrue(bridgeRunning.await(10, TimeUnit.SECONDS));
+        try {
+            kernel.getContext().addGlobalStateChangeListener(listener);
+            kernel.launch();
+            assertTrue(bridgeRunning.await(10, TimeUnit.SECONDS));
+        } finally {
+            kernel.getContext().removeGlobalStateChangeListener(listener);
+        }
     }
 
-    @Test // TODO add other tests
-    void GIVEN_bridge_WHEN_kernel_started_THEN_bridge_starts() throws Exception {
+    @Test
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_multiple_config_changes_consecutively_THEN_bridge_reinstalls_once(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, InterruptedException.class);
         startKernelWithConfig("config.yaml");
+
+        CountDownLatch bridgeRestarted = new CountDownLatch(1);
+        AtomicInteger numRestarts = new AtomicInteger();
+
+        kernel.getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && newState.equals(State.NEW)) {
+                numRestarts.incrementAndGet();
+                bridgeRestarted.countDown();
+            }
+        });
+
+        Topics config = kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
+                .lookupTopics(CONFIGURATION_CONFIG_KEY);
+
+        config.updateFromMap(Utils.immutableMap(BridgeConfig.KEY_CLIENT_ID, "new_client_id"), MERGE_UPDATE_BEHAVIOR.get());
+        config.updateFromMap(Utils.immutableMap(BridgeConfig.KEY_BROKER_URI, "tcp://newbroker:1234"), MERGE_UPDATE_BEHAVIOR.get());
+
+        assertTrue(bridgeRestarted.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
+        assertEquals(1, numRestarts.get());
     }
 
+    @Test
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_multiple_serialized_config_changes_occur_THEN_bridge_reinstalls_multiple_times(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, InterruptedException.class);
+        startKernelWithConfig("config.yaml");
+
+        Semaphore bridgeRestarted = new Semaphore(1);
+        bridgeRestarted.acquire();
+
+        kernel.getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && newState.equals(State.RUNNING)) {
+                bridgeRestarted.release();
+            }
+        });
+
+        Topics config = kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
+                .lookupTopics(CONFIGURATION_CONFIG_KEY);
+
+        int numRestarts = 5;
+        for (int i = 0; i < numRestarts; i++) {
+            // change the configuration and wait for bridge to restart
+            config.updateFromMap(Utils.immutableMap(BridgeConfig.KEY_BROKER_URI, String.format("tcp://brokeruri:%d", i)), MERGE_UPDATE_BEHAVIOR.get());
+            assertTrue(bridgeRestarted.tryAcquire(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_clientId_config_changes_THEN_bridge_reinstalls() throws Exception {
+        startKernelWithConfig("config.yaml");
+
+        CountDownLatch bridgeRestarted = new CountDownLatch(1);
+        kernel.getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && newState.equals(State.NEW)) {
+                bridgeRestarted.countDown();
+            }
+        });
+
+        Topics config = kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
+                .lookupTopics(CONFIGURATION_CONFIG_KEY);
+        config.updateFromMap(Utils.immutableMap(BridgeConfig.KEY_CLIENT_ID, "new_client_id"), MERGE_UPDATE_BEHAVIOR.get());
+
+        assertTrue(bridgeRestarted.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_valid_mqttTopicMapping_updated_THEN_mapping_updated(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, MqttException.class);
+        startKernelWithConfig("config.yaml");
+        TopicMapping topicMapping = kernel.getContext().get(TopicMapping.class);
+        assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
+
+        CountDownLatch bridgeRestarted = new CountDownLatch(1);
+        kernel.getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && newState.equals(State.NEW)) {
+                bridgeRestarted.countDown();
+            }
+        });
+
+        Topics mappingConfigTopics = kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
+                .lookupTopics(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_MQTT_TOPIC_MAPPING);
+
+        mappingConfigTopics.replaceAndWait(Utils.immutableMap("m1",
+                Utils.immutableMap("topic", "mqtt/topic", "source", TopicMapping.TopicType.LocalMqtt.toString(),
+                        "target", TopicMapping.TopicType.IotCore.toString()), "m2",
+                Utils.immutableMap("topic", "mqtt/topic2", "source", TopicMapping.TopicType.LocalMqtt.toString(),
+                        "target", TopicMapping.TopicType.Pubsub.toString()), "m3",
+                Utils.immutableMap("topic", "mqtt/topic3", "source", TopicMapping.TopicType.LocalMqtt.toString(),
+                        "target", TopicMapping.TopicType.IotCore.toString())));
+
+        kernel.getContext().waitForPublishQueueToClear();
+        assertThat(topicMapping.getMapping().size(), is(equalTo(3)));
+        assertFalse(bridgeRestarted.await(2, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_valid_mapping_provided_in_config_THEN_mapping_populated(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, MqttException.class);
+        startKernelWithConfig("config_with_mapping.yaml");
+        TopicMapping topicMapping = kernel.getContext().get(TopicMapping.class);
+
+        assertThat(() -> topicMapping.getMapping().size(), EventuallyLambdaMatcher.eventuallyEval(is(5)));
+        Map<String, TopicMapping.MappingEntry> expectedMapping = new HashMap<>();
+        expectedMapping.put("mapping1",
+                new TopicMapping.MappingEntry("topic/to/map/from/local/to/cloud", TopicMapping.TopicType.LocalMqtt,
+                        TopicMapping.TopicType.IotCore));
+        expectedMapping.put("mapping2",
+                new TopicMapping.MappingEntry("topic/to/map/from/local/to/pubsub", TopicMapping.TopicType.LocalMqtt,
+                        TopicMapping.TopicType.Pubsub));
+        expectedMapping.put("mapping3",
+                new TopicMapping.MappingEntry("topic/to/map/from/local/to/cloud/2", TopicMapping.TopicType.LocalMqtt,
+                        TopicMapping.TopicType.IotCore));
+        expectedMapping.put("mapping4",
+                new TopicMapping.MappingEntry("topic/to/map/from/local/to/pubsub/2", TopicMapping.TopicType.LocalMqtt,
+                        TopicMapping.TopicType.Pubsub, "a-prefix"));
+        expectedMapping.put("mapping5",
+                new TopicMapping.MappingEntry("topic/to/map/from/local/to/cloud/3", TopicMapping.TopicType.LocalMqtt,
+                        TopicMapping.TopicType.IotCore, "a-prefix"));
+
+        assertEquals(expectedMapping, topicMapping.getMapping());
+    }
+
+    @Test
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_empty_mqttTopicMapping_updated_THEN_mapping_not_updated(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, MqttException.class);
+        startKernelWithConfig("config.yaml");
+        TopicMapping topicMapping = kernel.getContext().get(TopicMapping.class);
+        assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
+
+        kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
+                .lookupTopics(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_MQTT_TOPIC_MAPPING)
+                .replaceAndWait(Collections.emptyMap());
+        // Block until subscriber has finished updating
+        kernel.getContext().waitForPublishQueueToClear();
+        assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
+    }
+
+    @Test
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_mapping_updated_with_empty_THEN_mapping_removed(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, MqttException.class);
+        startKernelWithConfig("config_with_mapping.yaml");
+        TopicMapping topicMapping = kernel.getContext().get(TopicMapping.class);
+
+        assertThat(() -> topicMapping.getMapping().size(), EventuallyLambdaMatcher.eventuallyEval(is(5)));
+        kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
+                .lookupTopics(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_MQTT_TOPIC_MAPPING)
+                .replaceAndWait(Collections.emptyMap());
+        // Block until subscriber has finished updating
+        kernel.getContext().waitForPublishQueueToClear();
+        assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
+    }
+
+    @Test
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_invalid_mqttTopicMapping_updated_THEN_mapping_not_updated(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, InvalidFormatException.class);
+        startKernelWithConfig("config.yaml");
+        TopicMapping topicMapping = kernel.getContext().get(TopicMapping.class);
+        assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
+
+        CountDownLatch bridgeErrored = new CountDownLatch(1);
+        GlobalStateChangeListener listener = (GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && service.getState().equals(State.ERRORED)) {
+                bridgeErrored.countDown();
+            }
+        };
+        kernel.getContext().addGlobalStateChangeListener(listener);
+
+        // Updating with invalid mapping (Providing type as Pubsub-Invalid)
+        Topics mappingConfigTopics = kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
+                .lookupTopics(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_MQTT_TOPIC_MAPPING);
+
+        mappingConfigTopics.replaceAndWait(Utils.immutableMap("m1",
+                Utils.immutableMap("topic", "mqtt/topic", "source", TopicMapping.TopicType.LocalMqtt.toString(),
+                        "target", TopicMapping.TopicType.IotCore.toString()), "m2",
+                Utils.immutableMap("topic", "mqtt/topic2", "source", TopicMapping.TopicType.LocalMqtt.toString(),
+                        "target", "Pubsub-Invalid"), "m3",
+                Utils.immutableMap("topic", "mqtt/topic3", "source", TopicMapping.TopicType.LocalMqtt.toString(),
+                        "target", TopicMapping.TopicType.IotCore.toString())));
+
+        // Block until subscriber has finished updating
+        kernel.getContext().waitForPublishQueueToClear();
+        assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
+
+        assertTrue(bridgeErrored.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
+    }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
@@ -6,12 +6,18 @@
 package com.aws.greengrass.integrationtests;
 
 import com.aws.greengrass.clientdevices.auth.CertificateManager;
+import com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService;
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
+import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.mqtt.bridge.BridgeConfig;
 import com.aws.greengrass.mqtt.bridge.MQTTBridge;
 import com.aws.greengrass.mqtt.bridge.MQTTBridgeTest;
+import com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
 import io.moquette.BrokerConstants;
@@ -22,17 +28,25 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -82,13 +96,91 @@ public class KeystoreTest {
                 bridgeRunning.countDown();
             }
         };
-        kernel.getContext().addGlobalStateChangeListener(listener);
-        kernel.launch();
-        assertTrue(bridgeRunning.await(10, TimeUnit.SECONDS));
+        try {
+            kernel.getContext().addGlobalStateChangeListener(listener);
+            kernel.launch();
+            assertTrue(bridgeRunning.await(10, TimeUnit.SECONDS));
+        } finally {
+            kernel.getContext().removeGlobalStateChangeListener(listener);
+        }
     }
 
-    @Test // TODO add other tests
-    void GIVEN_bridge_WHEN_kernel_started_THEN_bridge_starts() throws Exception {
+    @Test
+    void GIVEN_mqtt_bridge_WHEN_cda_ca_conf_changed_THEN_bridge_keystore_updated() throws Exception {
         startKernelWithConfig("config.yaml");
+
+        CountDownLatch keyStoreUpdated = new CountDownLatch(1);
+        MQTTClientKeyStore keyStore = kernel.getContext().get(MQTTClientKeyStore.class);
+        keyStore.listenToCAUpdates(keyStoreUpdated::countDown);
+
+        Topic certificateAuthoritiesTopic = kernel.getConfig().lookup(
+                SERVICES_NAMESPACE_TOPIC,
+                ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME,
+                RUNTIME_STORE_NAMESPACE_TOPIC,
+                ClientDevicesAuthService.CERTIFICATES_KEY,
+                ClientDevicesAuthService.AUTHORITIES_TOPIC
+        );
+
+        // update topic with CA
+        certificateAuthoritiesTopic.withValue(
+                CertificateHelper.toPem(
+                        CertificateHelper.createCACertificate(
+                                CertificateStore.newRSAKeyPair(2048),
+                                Date.from(Instant.now()),
+                                Date.from(Instant.now().plusSeconds(100)),
+                                "CA"
+                        )));
+
+        assertTrue(keyStoreUpdated.await(5L, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void GIVEN_mqtt_bridge_WHEN_cda_ca_conf_changed_after_shutdown_THEN_bridge_keystore_not_updated(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, IllegalArgumentException.class);
+        ignoreExceptionOfType(context, NullPointerException.class);
+
+        startKernelWithConfig("config.yaml");
+
+        CountDownLatch keyStoreUpdated = new CountDownLatch(1);
+        MQTTClientKeyStore keyStore = kernel.getContext().get(MQTTClientKeyStore.class);
+        keyStore.listenToCAUpdates(keyStoreUpdated::countDown);
+
+        Topic certificateAuthoritiesTopic = kernel.getConfig().lookup(
+                SERVICES_NAMESPACE_TOPIC,
+                ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME,
+                RUNTIME_STORE_NAMESPACE_TOPIC,
+                ClientDevicesAuthService.CERTIFICATES_KEY,
+                ClientDevicesAuthService.AUTHORITIES_TOPIC
+        );
+
+        // break bridge
+        CountDownLatch bridgeIsBroken = new CountDownLatch(1);
+        GlobalStateChangeListener listener = (GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && service.getState().equals(State.BROKEN)) {
+                bridgeIsBroken.countDown();
+            }
+        };
+        Topic brokerUriTopic = kernel.getConfig().lookup(
+                SERVICES_NAMESPACE_TOPIC,
+                MQTTBridge.SERVICE_NAME,
+                CONFIGURATION_CONFIG_KEY,
+                BridgeConfig.KEY_BROKER_URI
+        );
+        brokerUriTopic.withValue("garbage");
+        kernel.getContext().addGlobalStateChangeListener(listener);
+        assertTrue(bridgeIsBroken.await(10L, TimeUnit.SECONDS));
+
+        // update topic with CA
+        certificateAuthoritiesTopic.withValue(
+                CertificateHelper.toPem(
+                        CertificateHelper.createCACertificate(
+                                CertificateStore.newRSAKeyPair(2048),
+                                Date.from(Instant.now()),
+                                Date.from(Instant.now().plusSeconds(100)),
+                                "CA"
+                        )));
+
+        // shouldn't update
+        assertFalse(keyStoreUpdated.await(5L, TimeUnit.SECONDS));
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
@@ -35,6 +35,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
@@ -123,13 +124,15 @@ public class KeystoreTest {
 
         // update topic with CA
         certificateAuthoritiesTopic.withValue(
-                CertificateHelper.toPem(
-                        CertificateHelper.createCACertificate(
-                                CertificateStore.newRSAKeyPair(2048),
-                                Date.from(Instant.now()),
-                                Date.from(Instant.now().plusSeconds(100)),
-                                "CA"
-                        )));
+                Collections.singletonList(
+                        CertificateHelper.toPem(
+                                CertificateHelper.createCACertificate(
+                                        CertificateStore.newRSAKeyPair(2048),
+                                        Date.from(Instant.now()),
+                                        Date.from(Instant.now().plusSeconds(100)),
+                                        "CA"
+                                ))
+                ));
 
         assertTrue(keyStoreUpdated.await(5L, TimeUnit.SECONDS));
     }
@@ -172,13 +175,15 @@ public class KeystoreTest {
 
         // update topic with CA
         certificateAuthoritiesTopic.withValue(
-                CertificateHelper.toPem(
-                        CertificateHelper.createCACertificate(
-                                CertificateStore.newRSAKeyPair(2048),
-                                Date.from(Instant.now()),
-                                Date.from(Instant.now().plusSeconds(100)),
-                                "CA"
-                        )));
+                Collections.singletonList(
+                        CertificateHelper.toPem(
+                                CertificateHelper.createCACertificate(
+                                        CertificateStore.newRSAKeyPair(2048),
+                                        Date.from(Instant.now()),
+                                        Date.from(Instant.now().plusSeconds(100)),
+                                        "CA"
+                                ))
+                ));
 
         // shouldn't update
         assertFalse(keyStoreUpdated.await(5L, TimeUnit.SECONDS));

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -41,7 +41,7 @@ public final class BridgeConfig {
     static final String KEY_BROKER_SERVER_URI = "brokerServerUri"; // for backwards compatibility only
     public static final String KEY_BROKER_URI = "brokerUri";
     public static final String KEY_CLIENT_ID = "clientId";
-    static final String KEY_MQTT_TOPIC_MAPPING = "mqttTopicMapping";
+    public static final String KEY_MQTT_TOPIC_MAPPING = "mqttTopicMapping";
     static final String KEY_BROKER_CLIENT = "brokerClient";
     static final String KEY_VERSION = "version";
 

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -26,8 +26,6 @@ import com.aws.greengrass.mqtt.bridge.model.InvalidConfigurationException;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.util.BatchedSubscriber;
 import com.aws.greengrass.util.Utils;
-import lombok.AccessLevel;
-import lombok.Getter;
 
 import java.io.IOException;
 import java.security.KeyStoreException;
@@ -44,7 +42,6 @@ import javax.inject.Inject;
 public class MQTTBridge extends PluginService {
     public static final String SERVICE_NAME = "aws.greengrass.clientdevices.mqtt.Bridge";
 
-    @Getter(AccessLevel.PACKAGE) // Getter for unit tests
     private final TopicMapping topicMapping;
     private final MessageBridge messageBridge;
     private final Kernel kernel;

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/TopicMapping.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/TopicMapping.java
@@ -80,7 +80,7 @@ public class TopicMapping {
          * @param source the source integration to listen on
          * @param target the target integration to bridge to
          */
-        MappingEntry(String topic, TopicType source, TopicType target) {
+        public MappingEntry(String topic, TopicType source, TopicType target) {
             this.topic = topic;
             this.source = source;
             this.target = target;

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
@@ -6,72 +6,38 @@
 package com.aws.greengrass.mqtt.bridge;
 
 import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
-import com.aws.greengrass.clientdevices.auth.CertificateManager;
-import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
-import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
-import com.aws.greengrass.config.UpdateBehaviorTree;
 import com.aws.greengrass.dependency.Context;
-import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService;
-import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
-import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore;
 import com.aws.greengrass.mqtt.bridge.clients.IoTCoreClient;
 import com.aws.greengrass.mqtt.bridge.clients.LocalMqttClientFactory;
-import com.aws.greengrass.mqtt.bridge.clients.MQTTClient;
+import com.aws.greengrass.mqtt.bridge.clients.MessageClient;
 import com.aws.greengrass.mqtt.bridge.clients.PubSubClient;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
-import com.aws.greengrass.util.Utils;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
-import com.github.grantwest.eventually.EventuallyLambdaMatcher;
-import io.moquette.BrokerConstants;
-import io.moquette.broker.Server;
-import io.moquette.broker.config.IConfig;
-import io.moquette.broker.config.MemoryConfig;
-import org.eclipse.paho.client.mqttv3.MqttException;
+import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
-import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
-import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -82,295 +48,12 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class MQTTBridgeTest extends GGServiceTestUtil {
-    private static final long TEST_TIME_OUT_SEC = 30L;
 
-    private static final Supplier<UpdateBehaviorTree> MERGE_UPDATE_BEHAVIOR =
-            () -> new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.MERGE, System.currentTimeMillis());
-
-    private Kernel kernel;
-    private GlobalStateChangeListener listener;
-    private Server broker;
-    private ScheduledExecutorService ses;
-
-    @TempDir
-    Path rootDir;
-
-    @Mock
-    CertificateManager mockCertificateManager;
-
-    @BeforeEach
-    void setup() throws IOException {
-        // Set this property for kernel to scan its own classpath to find plugins
-        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
-
-        kernel = new Kernel();
-        kernel.getContext().put(CertificateManager.class, mockCertificateManager);
-        IConfig defaultConfig = new MemoryConfig(new Properties());
-        defaultConfig.setProperty(BrokerConstants.PORT_PROPERTY_NAME, "8883");
-        broker = new Server();
-        broker.startServer(defaultConfig);
-        ses = new ScheduledThreadPoolExecutor(1);
-    }
+    private final ExecutorService executor = TestUtils.synchronousExecutorService();
 
     @AfterEach
     void cleanup() {
-        kernel.shutdown();
-        broker.stopServer();
-        ses.shutdownNow();
-    }
-
-    private void startKernelWithConfig(String configFileName) throws InterruptedException {
-        CountDownLatch bridgeRunning = new CountDownLatch(1);
-        kernel.parseArgs("-r", rootDir.toAbsolutePath().toString(), "-i",
-                MQTTBridgeTest.class.getResource(configFileName).toString());
-        listener = (GreengrassService service, State was, State newState) -> {
-            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && service.getState().equals(State.RUNNING)) {
-                bridgeRunning.countDown();
-            }
-        };
-        kernel.getContext().addGlobalStateChangeListener(listener);
-        kernel.launch();
-
-        assertTrue(bridgeRunning.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
-    }
-
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_multiple_config_changes_consecutively_THEN_bridge_reinstalls_once(ExtensionContext context)
-            throws Exception {
-        ignoreExceptionOfType(context, InterruptedException.class);
-        startKernelWithConfig("config.yaml");
-
-        CountDownLatch bridgeRestarted = new CountDownLatch(1);
-        AtomicInteger numRestarts = new AtomicInteger();
-
-        kernel.getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
-            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && newState.equals(State.NEW)) {
-                numRestarts.incrementAndGet();
-                bridgeRestarted.countDown();
-            }
-        });
-
-        Topics config = kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
-                .lookupTopics(CONFIGURATION_CONFIG_KEY);
-
-        config.updateFromMap(Utils.immutableMap(BridgeConfig.KEY_CLIENT_ID, "new_client_id"), MERGE_UPDATE_BEHAVIOR.get());
-        config.updateFromMap(Utils.immutableMap(BridgeConfig.KEY_BROKER_URI, "tcp://newbroker:1234"), MERGE_UPDATE_BEHAVIOR.get());
-
-        assertTrue(bridgeRestarted.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
-        assertEquals(1, numRestarts.get());
-    }
-
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_multiple_serialized_config_changes_occur_THEN_bridge_reinstalls_multiple_times(ExtensionContext context)
-            throws Exception {
-        ignoreExceptionOfType(context, InterruptedException.class);
-        startKernelWithConfig("config.yaml");
-
-        Semaphore bridgeRestarted = new Semaphore(1);
-        bridgeRestarted.acquire();
-
-        kernel.getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
-            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && newState.equals(State.RUNNING)) {
-                bridgeRestarted.release();
-            }
-        });
-
-        Topics config = kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
-                .lookupTopics(CONFIGURATION_CONFIG_KEY);
-
-        int numRestarts = 5;
-        for (int i = 0; i < numRestarts; i++) {
-            // change the configuration and wait for bridge to restart
-            config.updateFromMap(Utils.immutableMap(BridgeConfig.KEY_BROKER_URI, String.format("tcp://brokeruri:%d", i)), MERGE_UPDATE_BEHAVIOR.get());
-            assertTrue(bridgeRestarted.tryAcquire(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
-        }
-    }
-
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_clientId_config_changes_THEN_bridge_reinstalls() throws Exception {
-        startKernelWithConfig("config.yaml");
-
-        CountDownLatch bridgeRestarted = new CountDownLatch(1);
-        kernel.getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
-            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && newState.equals(State.NEW)) {
-                bridgeRestarted.countDown();
-            }
-        });
-
-        Topics config = kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
-                .lookupTopics(CONFIGURATION_CONFIG_KEY);
-        config.updateFromMap(Utils.immutableMap(BridgeConfig.KEY_CLIENT_ID, "new_client_id"), MERGE_UPDATE_BEHAVIOR.get());
-
-        assertTrue(bridgeRestarted.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
-    }
-
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_start_kernel_THEN_bridge_starts_successfully() throws Exception {
-        startKernelWithConfig("config.yaml");
-    }
-
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_valid_mqttTopicMapping_updated_THEN_mapping_updated(ExtensionContext context)
-            throws Exception {
-        ignoreExceptionOfType(context, MqttException.class);
-        startKernelWithConfig("config.yaml");
-        TopicMapping topicMapping = ((MQTTBridge) kernel.locate(MQTTBridge.SERVICE_NAME)).getTopicMapping();
-        assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
-
-        CountDownLatch bridgeRestarted = new CountDownLatch(1);
-        kernel.getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
-            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && newState.equals(State.NEW)) {
-                bridgeRestarted.countDown();
-            }
-        });
-
-        Topics mappingConfigTopics = kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
-                .lookupTopics(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_MQTT_TOPIC_MAPPING);
-
-        mappingConfigTopics.replaceAndWait(Utils.immutableMap("m1",
-                Utils.immutableMap("topic", "mqtt/topic", "source", TopicMapping.TopicType.LocalMqtt.toString(),
-                        "target", TopicMapping.TopicType.IotCore.toString()), "m2",
-                Utils.immutableMap("topic", "mqtt/topic2", "source", TopicMapping.TopicType.LocalMqtt.toString(),
-                        "target", TopicMapping.TopicType.Pubsub.toString()), "m3",
-                Utils.immutableMap("topic", "mqtt/topic3", "source", TopicMapping.TopicType.LocalMqtt.toString(),
-                        "target", TopicMapping.TopicType.IotCore.toString())));
-
-        kernel.getContext().runOnPublishQueueAndWait(() -> {
-        });
-        assertThat(topicMapping.getMapping().size(), is(equalTo(3)));
-        assertFalse(bridgeRestarted.await(2, TimeUnit.SECONDS));
-    }
-
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_valid_mapping_provided_in_config_THEN_mapping_populated(ExtensionContext context)
-            throws Exception {
-        ignoreExceptionOfType(context, MqttException.class);
-        startKernelWithConfig("config_with_mapping.yaml");
-        TopicMapping topicMapping = ((MQTTBridge) kernel.locate(MQTTBridge.SERVICE_NAME)).getTopicMapping();
-
-        assertThat(() -> topicMapping.getMapping().size(), EventuallyLambdaMatcher.eventuallyEval(is(5)));
-        Map<String, TopicMapping.MappingEntry> expectedMapping = new HashMap<>();
-        expectedMapping.put("mapping1",
-                new TopicMapping.MappingEntry("topic/to/map/from/local/to/cloud", TopicMapping.TopicType.LocalMqtt,
-                        TopicMapping.TopicType.IotCore));
-        expectedMapping.put("mapping2",
-                new TopicMapping.MappingEntry("topic/to/map/from/local/to/pubsub", TopicMapping.TopicType.LocalMqtt,
-                        TopicMapping.TopicType.Pubsub));
-        expectedMapping.put("mapping3",
-                new TopicMapping.MappingEntry("topic/to/map/from/local/to/cloud/2", TopicMapping.TopicType.LocalMqtt,
-                        TopicMapping.TopicType.IotCore));
-        expectedMapping.put("mapping4",
-                new TopicMapping.MappingEntry("topic/to/map/from/local/to/pubsub/2", TopicMapping.TopicType.LocalMqtt,
-                        TopicMapping.TopicType.Pubsub, "a-prefix"));
-        expectedMapping.put("mapping5",
-                new TopicMapping.MappingEntry("topic/to/map/from/local/to/cloud/3", TopicMapping.TopicType.LocalMqtt,
-                        TopicMapping.TopicType.IotCore, "a-prefix"));
-
-        assertEquals(expectedMapping, topicMapping.getMapping());
-    }
-
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_empty_mqttTopicMapping_updated_THEN_mapping_not_updated(ExtensionContext context)
-            throws Exception {
-        ignoreExceptionOfType(context, MqttException.class);
-        startKernelWithConfig("config.yaml");
-        TopicMapping topicMapping = ((MQTTBridge) kernel.locate(MQTTBridge.SERVICE_NAME)).getTopicMapping();
-        assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
-
-        kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
-                .lookupTopics(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_MQTT_TOPIC_MAPPING)
-                .replaceAndWait(Collections.EMPTY_MAP);
-        // Block until subscriber has finished updating
-        kernel.getContext().runOnPublishQueueAndWait(() -> {
-        });
-        assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
-    }
-
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_mapping_updated_with_empty_THEN_mapping_removed(ExtensionContext context)
-            throws Exception {
-        ignoreExceptionOfType(context, MqttException.class);
-        startKernelWithConfig("config_with_mapping.yaml");
-        TopicMapping topicMapping = ((MQTTBridge) kernel.locate(MQTTBridge.SERVICE_NAME)).getTopicMapping();
-
-        assertThat(() -> topicMapping.getMapping().size(), EventuallyLambdaMatcher.eventuallyEval(is(5)));
-        kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
-                .lookupTopics(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_MQTT_TOPIC_MAPPING)
-                .replaceAndWait(Collections.EMPTY_MAP);
-        // Block until subscriber has finished updating
-        kernel.getContext().runOnPublishQueueAndWait(() -> {
-        });
-        assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
-    }
-
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_invalid_mqttTopicMapping_updated_THEN_mapping_not_updated(ExtensionContext context)
-            throws Exception {
-        ignoreExceptionOfType(context, InvalidFormatException.class);
-        startKernelWithConfig("config.yaml");
-        TopicMapping topicMapping = ((MQTTBridge) kernel.locate(MQTTBridge.SERVICE_NAME)).getTopicMapping();
-        assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
-
-        kernel.getContext().removeGlobalStateChangeListener(listener);
-        CountDownLatch bridgeErrored = new CountDownLatch(1);
-
-        GlobalStateChangeListener listener = (GreengrassService service, State was, State newState) -> {
-            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && service.getState().equals(State.ERRORED)) {
-                bridgeErrored.countDown();
-            }
-        };
-
-        kernel.getContext().addGlobalStateChangeListener(listener);
-
-        // Updating with invalid mapping (Providing type as Pubsub-Invalid)
-        Topics mappingConfigTopics = kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
-                .lookupTopics(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_MQTT_TOPIC_MAPPING);
-
-        mappingConfigTopics.replaceAndWait(Utils.immutableMap("m1",
-                Utils.immutableMap("topic", "mqtt/topic", "source", TopicMapping.TopicType.LocalMqtt.toString(),
-                        "target", TopicMapping.TopicType.IotCore.toString()), "m2",
-                Utils.immutableMap("topic", "mqtt/topic2", "source", TopicMapping.TopicType.LocalMqtt.toString(),
-                        "target", "Pubsub-Invalid"), "m3",
-                Utils.immutableMap("topic", "mqtt/topic3", "source", TopicMapping.TopicType.LocalMqtt.toString(),
-                        "target", TopicMapping.TopicType.IotCore.toString())));
-
-        // Block until subscriber has finished updating
-        kernel.getContext().runOnPublishQueueAndWait(() -> {
-        });
-        assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
-
-        assertTrue(bridgeErrored.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
-    }
-
-    @Test // TODO refactor to int tests
-    void GIVEN_mqtt_bridge_WHEN_cda_ca_conf_changed_THEN_bridge_keystore_updated_int() throws Exception {
-        startKernelWithConfig("config.yaml");
-
-        CountDownLatch keyStoreUpdated = new CountDownLatch(1);
-        MQTTClientKeyStore keyStore = kernel.getContext().get(MQTTClientKeyStore.class);
-        keyStore.listenToCAUpdates(keyStoreUpdated::countDown);
-
-        Topic certificateAuthoritiesTopic = kernel.getConfig().lookup(
-                SERVICES_NAMESPACE_TOPIC,
-                ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME,
-                RUNTIME_STORE_NAMESPACE_TOPIC,
-                ClientDevicesAuthService.CERTIFICATES_KEY,
-                ClientDevicesAuthService.AUTHORITIES_TOPIC
-        );
-
-        // update topic with CA
-        certificateAuthoritiesTopic.withValue(
-                Collections.singletonList(
-                        CertificateHelper.toPem(
-                                CertificateHelper.createCACertificate(
-                                        CertificateStore.newRSAKeyPair(2048),
-                                        Date.from(Instant.now()),
-                                        Date.from(Instant.now().plusSeconds(100)),
-                                        "CA"
-                                ))
-                ));
-
-        assertTrue(keyStoreUpdated.await(10L, TimeUnit.SECONDS));
+        executor.shutdownNow();
     }
 
     @Test
@@ -384,7 +67,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         Kernel mockKernel = mock(Kernel.class);
         MQTTClientKeyStore mockMqttClientKeyStore = mock(MQTTClientKeyStore.class);
         MQTTBridge mqttBridge;
-        LocalMqttClientFactory localMqttClientFactory = new LocalMqttClientFactory(mockMqttClientKeyStore, ses);
+        LocalMqttClientFactory localMqttClientFactory = new FakeMqttClientFactory();
 
         try (Context context = new Context()) {
             Topics config = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
@@ -393,12 +76,10 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
             config.lookup(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_CLIENT_ID)
                     .dflt("clientId");
 
-            localMqttClientFactory.setConfig(BridgeConfig.fromTopics(config));
-
             try (MqttClient mockIotMqttClient = mock(MqttClient.class)) {
                 mqttBridge =
                         new MQTTBridge(config, mockTopicMapping, mockMessageBridge, mockPubSubIPCAgent, mockIotMqttClient,
-                                mockKernel, mockMqttClientKeyStore, localMqttClientFactory, ses);
+                                mockKernel, mockMqttClientKeyStore, localMqttClientFactory, executor);
             }
 
             ClientDevicesAuthService mockClientAuthService = mock(ClientDevicesAuthService.class);
@@ -440,58 +121,6 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         }
     }
 
-    @Test // TODO refactor to int tests
-    void GIVEN_mqtt_bridge_WHEN_cda_ca_conf_changed_after_shutdown_THEN_bridge_keystore_not_updated_int(ExtensionContext context) throws Exception {
-        ignoreExceptionOfType(context, IllegalArgumentException.class);
-        ignoreExceptionOfType(context, NullPointerException.class);
-
-        startKernelWithConfig("config.yaml");
-
-        CountDownLatch keyStoreUpdated = new CountDownLatch(1);
-        MQTTClientKeyStore keyStore = kernel.getContext().get(MQTTClientKeyStore.class);
-        keyStore.listenToCAUpdates(keyStoreUpdated::countDown);
-
-        Topic certificateAuthoritiesTopic = kernel.getConfig().lookup(
-                SERVICES_NAMESPACE_TOPIC,
-                ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME,
-                RUNTIME_STORE_NAMESPACE_TOPIC,
-                ClientDevicesAuthService.CERTIFICATES_KEY,
-                ClientDevicesAuthService.AUTHORITIES_TOPIC
-        );
-
-        // break bridge
-        CountDownLatch bridgeIsBroken = new CountDownLatch(1);
-        GlobalStateChangeListener listener = (GreengrassService service, State was, State newState) -> {
-            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && service.getState().equals(State.BROKEN)) {
-                bridgeIsBroken.countDown();
-            }
-        };
-        Topic brokerUriTopic = kernel.getConfig().lookup(
-                SERVICES_NAMESPACE_TOPIC,
-                MQTTBridge.SERVICE_NAME,
-                CONFIGURATION_CONFIG_KEY,
-                BridgeConfig.KEY_BROKER_URI
-        );
-        brokerUriTopic.withValue("garbage");
-        kernel.getContext().addGlobalStateChangeListener(listener);
-        assertTrue(bridgeIsBroken.await(10L, TimeUnit.SECONDS));
-
-        // update topic with CA
-        certificateAuthoritiesTopic.withValue(
-                Collections.singletonList(
-                        CertificateHelper.toPem(
-                                CertificateHelper.createCACertificate(
-                                        CertificateStore.newRSAKeyPair(2048),
-                                        Date.from(Instant.now()),
-                                        Date.from(Instant.now().plusSeconds(100)),
-                                        "CA"
-                                ))
-                ));
-
-        // shouldn't update
-        assertFalse(keyStoreUpdated.await(5L, TimeUnit.SECONDS));
-    }
-
     @Test
     void GIVEN_mqtt_bridge_WHEN_cda_ca_conf_changed_after_shutdown_THEN_bridge_keystore_not_updated(ExtensionContext extensionContext) throws Exception {
         ignoreExceptionOfType(extensionContext, InterruptedException.class);
@@ -503,7 +132,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         Kernel mockKernel = mock(Kernel.class);
         MQTTClientKeyStore mockMqttClientKeyStore = mock(MQTTClientKeyStore.class);
         MQTTBridge mqttBridge;
-        LocalMqttClientFactory localMqttClientFactory = new LocalMqttClientFactory(mockMqttClientKeyStore, ses);
+        LocalMqttClientFactory localMqttClientFactory = new FakeMqttClientFactory();
 
         try (Context context = new Context()) {
             Topics config = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
@@ -512,12 +141,10 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
             config.lookup(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_CLIENT_ID)
                     .dflt("clientId");
 
-            localMqttClientFactory.setConfig(BridgeConfig.fromTopics(config));
-
             try (MqttClient mockIotMqttClient = mock(MqttClient.class)) {
                 mqttBridge =
                         new MQTTBridge(config, mockTopicMapping, mockMessageBridge, mockPubSubIPCAgent, mockIotMqttClient,
-                                mockKernel, mockMqttClientKeyStore, localMqttClientFactory, ses);
+                                mockKernel, mockMqttClientKeyStore, localMqttClientFactory, executor);
             }
 
             ClientDevicesAuthService mockClientAuthService = mock(ClientDevicesAuthService.class);
@@ -549,7 +176,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         MessageBridge mockMessageBridge = mock(MessageBridge.class);
         Kernel mockKernel = mock(Kernel.class);
         MQTTClientKeyStore mockMqttClientKeyStore = mock(MQTTClientKeyStore.class);
-        LocalMqttClientFactory localMqttClientFactory = new LocalMqttClientFactory(mockMqttClientKeyStore, ses);
+        LocalMqttClientFactory localMqttClientFactory = new FakeMqttClientFactory();
 
         Topics config = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
         config.lookup(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_BROKER_URI)
@@ -557,11 +184,9 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         config.lookup(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_CLIENT_ID)
                 .dflt("clientId");
 
-        localMqttClientFactory.setConfig(BridgeConfig.fromTopics(config));
-
         MQTTBridge mqttBridge =
                 new MQTTBridge(config, mockTopicMapping, mockMessageBridge, mock(PubSubIPCEventStreamAgent.class),
-                        mock(MqttClient.class), mockKernel, mockMqttClientKeyStore, localMqttClientFactory, ses);
+                        mock(MqttClient.class), mockKernel, mockMqttClientKeyStore, localMqttClientFactory, executor);
 
         ClientDevicesAuthService mockClientAuthService = mock(ClientDevicesAuthService.class);
         when(mockKernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME))
@@ -579,10 +204,42 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         mqttBridge.shutdown();
 
         verify(mockMessageBridge).addOrReplaceMessageClientAndUpdateSubscriptions(
-                eq(TopicMapping.TopicType.LocalMqtt), any(MQTTClient.class));
+                eq(TopicMapping.TopicType.LocalMqtt), any(MessageClient.class));
         verify(mockMessageBridge).addOrReplaceMessageClientAndUpdateSubscriptions(
                 eq(TopicMapping.TopicType.Pubsub), any(PubSubClient.class));
         verify(mockMessageBridge).addOrReplaceMessageClientAndUpdateSubscriptions(
                 eq(TopicMapping.TopicType.IotCore), any(IoTCoreClient.class));
+    }
+
+    static class FakeMqttClientFactory extends LocalMqttClientFactory {
+        public FakeMqttClientFactory() {
+            super(null, null);
+        }
+
+        @Override
+        public MessageClient createLocalMqttClient()  {
+            return new MessageClient() {
+                @Override
+                public void publish(Message message) {
+                }
+
+                @Override
+                public void updateSubscriptions(Set<String> topics, Consumer<Message> messageHandler) {
+                }
+
+                @Override
+                public boolean supportsTopicFilters() {
+                    return true;
+                }
+
+                @Override
+                public void start() {
+                }
+
+                @Override
+                public void stop() {
+                }
+            };
+        }
     }
 }

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
@@ -16,6 +16,8 @@ import com.aws.greengrass.mqtt.bridge.clients.IoTCoreClient;
 import com.aws.greengrass.mqtt.bridge.clients.LocalMqttClientFactory;
 import com.aws.greengrass.mqtt.bridge.clients.MessageClient;
 import com.aws.greengrass.mqtt.bridge.clients.PubSubClient;
+import com.aws.greengrass.mqtt.bridge.model.Message;
+import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
@@ -217,14 +219,14 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
         }
 
         @Override
-        public MessageClient createLocalMqttClient()  {
-            return new MessageClient() {
+        public MessageClient<MqttMessage> createLocalMqttClient()  {
+            return new MessageClient<MqttMessage>() {
                 @Override
-                public void publish(Message message) {
+                public void publish(MqttMessage message) {
                 }
 
                 @Override
-                public void updateSubscriptions(Set<String> topics, Consumer<Message> messageHandler) {
+                public void updateSubscriptions(Set<String> topics, Consumer<MqttMessage> messageHandler) {
                 }
 
                 @Override
@@ -238,6 +240,11 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
 
                 @Override
                 public void stop() {
+                }
+
+                @Override
+                public MqttMessage convertMessage(Message message) {
+                    return (MqttMessage) message.toMqtt();
                 }
             };
         }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Move integration tests from `MQTTBridgeTest` to `KeystoreTest` and `ConfigTest` integration test classes

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
