### PR TITLE
fix: toPojo when reading cda topic

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -25,7 +25,6 @@ import com.aws.greengrass.mqtt.bridge.clients.PubSubClient;
 import com.aws.greengrass.mqtt.bridge.model.InvalidConfigurationException;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.util.BatchedSubscriber;
-import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.Utils;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
@@ -360,13 +360,15 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
 
         // update topic with CA
         certificateAuthoritiesTopic.withValue(
-                CertificateHelper.toPem(
-                        CertificateHelper.createCACertificate(
-                                CertificateStore.newRSAKeyPair(2048),
-                                Date.from(Instant.now()),
-                                Date.from(Instant.now().plusSeconds(100)),
-                                "CA"
-                        )));
+                Collections.singletonList(
+                        CertificateHelper.toPem(
+                                CertificateHelper.createCACertificate(
+                                        CertificateStore.newRSAKeyPair(2048),
+                                        Date.from(Instant.now()),
+                                        Date.from(Instant.now().plusSeconds(100)),
+                                        "CA"
+                                ))
+                ));
 
         assertTrue(keyStoreUpdated.await(5L, TimeUnit.SECONDS));
     }
@@ -476,13 +478,15 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
 
         // update topic with CA
         certificateAuthoritiesTopic.withValue(
-                CertificateHelper.toPem(
-                        CertificateHelper.createCACertificate(
-                                CertificateStore.newRSAKeyPair(2048),
-                                Date.from(Instant.now()),
-                                Date.from(Instant.now().plusSeconds(100)),
-                                "CA"
-                        )));
+                Collections.singletonList(
+                        CertificateHelper.toPem(
+                                CertificateHelper.createCACertificate(
+                                        CertificateStore.newRSAKeyPair(2048),
+                                        Date.from(Instant.now()),
+                                        Date.from(Instant.now().plusSeconds(100)),
+                                        "CA"
+                                ))
+                ));
 
         // shouldn't update
         assertFalse(keyStoreUpdated.await(5L, TimeUnit.SECONDS));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
UATs are failing because bridge is reading CDA CA topic incorrectly, reverting back to previous approach of topic.toPOJO

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
