### PR TITLE
chore: upgrade nucleus for mqtt5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.10.0-SNAPSHOT</version>
+            <version>${nucleus.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.6.0-SNAPSHOT</version>
+            <version>${nucleus.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -393,6 +393,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <nucleus.version>2.10.0-SNAPSHOT</nucleus.version>
         <skipTests>false</skipTests>
         <groups></groups>
         <mqttbridgejar.name>aws.greengrass.clientdevices.mqtt.Bridge</mqttbridgejar.name>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.6.0-SNAPSHOT</version>
+            <version>2.10.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Bump nucleus to 2.10.0-SNAPSHOT to get mqtt5 models

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
