### PR TITLE
refactor: use BridgeIntegrationTest for existing integration tests

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
@@ -5,44 +5,29 @@
 
 package com.aws.greengrass.integrationtests;
 
-import com.aws.greengrass.clientdevices.auth.CertificateManager;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.config.UpdateBehaviorTree;
 import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.integrationtests.extensions.BridgeIntegrationTest;
+import com.aws.greengrass.integrationtests.extensions.BridgeIntegrationTestContext;
+import com.aws.greengrass.integrationtests.extensions.Broker;
+import com.aws.greengrass.integrationtests.extensions.TestWithMqtt3Broker;
+import com.aws.greengrass.integrationtests.extensions.WithKernel;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
-import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.mqtt.bridge.BridgeConfig;
 import com.aws.greengrass.mqtt.bridge.MQTTBridge;
 import com.aws.greengrass.mqtt.bridge.TopicMapping;
-import com.aws.greengrass.testcommons.testutilities.GGExtension;
-import com.aws.greengrass.testcommons.testutilities.TestUtils;
-import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
 import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.github.grantwest.eventually.EventuallyLambdaMatcher;
-import io.moquette.BrokerConstants;
-import io.moquette.broker.Server;
-import io.moquette.broker.config.IConfig;
-import io.moquette.broker.config.MemoryConfig;
 import org.eclipse.paho.client.mqttv3.MqttException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.io.TempDir;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -56,82 +41,31 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
-@ExtendWith({GGExtension.class, UniqueRootPathExtension.class, MockitoExtension.class})
+@BridgeIntegrationTest
 public class ConfigTest {
     private static final long TEST_TIME_OUT_SEC = 30L;
     private static final Supplier<UpdateBehaviorTree> MERGE_UPDATE_BEHAVIOR =
             () -> new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.MERGE, System.currentTimeMillis());
 
-    @TempDir
-    Path rootDir;
+    BridgeIntegrationTestContext testContext;
 
-    Kernel kernel;
-
-    // TODO mqtt5
-    Server broker;
-
-    ExecutorService executorService = TestUtils.synchronousExecutorService();
-
-    @BeforeEach
-    void setup() throws IOException {
-        // Set this property for kernel to scan its own classpath to find plugins
-        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
-
-        kernel = new Kernel();
-        kernel.getContext().put(CertificateManager.class, mock(CertificateManager.class));
-
-        IConfig defaultConfig = new MemoryConfig(new Properties());
-        defaultConfig.setProperty(BrokerConstants.PORT_PROPERTY_NAME, "8883");
-        broker = new Server();
-        broker.startServer(defaultConfig);
-
-        executorService = new ScheduledThreadPoolExecutor(1);
-    }
-
-    @AfterEach
-    void cleanup() {
-        kernel.shutdown();
-        broker.stopServer();
-        executorService.shutdownNow();
-    }
-
-    private void startKernelWithConfig(String configFileName) throws InterruptedException {
-        CountDownLatch bridgeRunning = new CountDownLatch(1);
-        kernel.parseArgs("-r", rootDir.toAbsolutePath().toString(), "-i",
-                getClass().getResource(configFileName).toString());
-        GlobalStateChangeListener listener = (GreengrassService service, State was, State newState) -> {
-            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && service.getState().equals(State.RUNNING)) {
-                bridgeRunning.countDown();
-            }
-        };
-        try {
-            kernel.getContext().addGlobalStateChangeListener(listener);
-            kernel.launch();
-            assertTrue(bridgeRunning.await(10, TimeUnit.SECONDS));
-        } finally {
-            kernel.getContext().removeGlobalStateChangeListener(listener);
-        }
-    }
-
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_multiple_config_changes_consecutively_THEN_bridge_reinstalls_once(ExtensionContext context)
-            throws Exception {
+    @TestWithMqtt3Broker
+    @WithKernel("config.yaml")
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_multiple_config_changes_consecutively_THEN_bridge_reinstalls_once(Broker broker, ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, InterruptedException.class);
-        startKernelWithConfig("config.yaml");
 
         CountDownLatch bridgeRestarted = new CountDownLatch(1);
         AtomicInteger numRestarts = new AtomicInteger();
 
-        kernel.getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
+        testContext.getKernel().getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
             if (service.getName().equals(MQTTBridge.SERVICE_NAME) && newState.equals(State.NEW)) {
                 numRestarts.incrementAndGet();
                 bridgeRestarted.countDown();
             }
         });
 
-        Topics config = kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
+        Topics config = testContext.getKernel().locate(MQTTBridge.SERVICE_NAME).getConfig()
                 .lookupTopics(CONFIGURATION_CONFIG_KEY);
 
         config.updateFromMap(Utils.immutableMap(BridgeConfig.KEY_CLIENT_ID, "new_client_id"), MERGE_UPDATE_BEHAVIOR.get());
@@ -141,22 +75,21 @@ public class ConfigTest {
         assertEquals(1, numRestarts.get());
     }
 
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_multiple_serialized_config_changes_occur_THEN_bridge_reinstalls_multiple_times(ExtensionContext context)
-            throws Exception {
+    @TestWithMqtt3Broker
+    @WithKernel("config.yaml")
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_multiple_serialized_config_changes_occur_THEN_bridge_reinstalls_multiple_times(Broker broker, ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, InterruptedException.class);
-        startKernelWithConfig("config.yaml");
 
         Semaphore bridgeRestarted = new Semaphore(1);
         bridgeRestarted.acquire();
 
-        kernel.getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
+        testContext.getKernel().getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
             if (service.getName().equals(MQTTBridge.SERVICE_NAME) && newState.equals(State.RUNNING)) {
                 bridgeRestarted.release();
             }
         });
 
-        Topics config = kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
+        Topics config = testContext.getKernel().locate(MQTTBridge.SERVICE_NAME).getConfig()
                 .lookupTopics(CONFIGURATION_CONFIG_KEY);
 
         int numRestarts = 5;
@@ -167,40 +100,39 @@ public class ConfigTest {
         }
     }
 
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_clientId_config_changes_THEN_bridge_reinstalls() throws Exception {
-        startKernelWithConfig("config.yaml");
-
+    @TestWithMqtt3Broker
+    @WithKernel("config.yaml")
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_clientId_config_changes_THEN_bridge_reinstalls(Broker broker) throws Exception {
         CountDownLatch bridgeRestarted = new CountDownLatch(1);
-        kernel.getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
+        testContext.getKernel().getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
             if (service.getName().equals(MQTTBridge.SERVICE_NAME) && newState.equals(State.NEW)) {
                 bridgeRestarted.countDown();
             }
         });
 
-        Topics config = kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
+        Topics config = testContext.getKernel().locate(MQTTBridge.SERVICE_NAME).getConfig()
                 .lookupTopics(CONFIGURATION_CONFIG_KEY);
         config.updateFromMap(Utils.immutableMap(BridgeConfig.KEY_CLIENT_ID, "new_client_id"), MERGE_UPDATE_BEHAVIOR.get());
 
         assertTrue(bridgeRestarted.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
     }
 
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_valid_mqttTopicMapping_updated_THEN_mapping_updated(ExtensionContext context)
-            throws Exception {
+    @TestWithMqtt3Broker
+    @WithKernel("config.yaml")
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_valid_mqttTopicMapping_updated_THEN_mapping_updated(Broker broker, ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, MqttException.class);
-        startKernelWithConfig("config.yaml");
-        TopicMapping topicMapping = kernel.getContext().get(TopicMapping.class);
+
+        TopicMapping topicMapping = testContext.getKernel().getContext().get(TopicMapping.class);
         assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
 
         CountDownLatch bridgeRestarted = new CountDownLatch(1);
-        kernel.getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
+        testContext.getKernel().getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
             if (service.getName().equals(MQTTBridge.SERVICE_NAME) && newState.equals(State.NEW)) {
                 bridgeRestarted.countDown();
             }
         });
 
-        Topics mappingConfigTopics = kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
+        Topics mappingConfigTopics = testContext.getKernel().locate(MQTTBridge.SERVICE_NAME).getConfig()
                 .lookupTopics(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_MQTT_TOPIC_MAPPING);
 
         mappingConfigTopics.replaceAndWait(Utils.immutableMap("m1",
@@ -211,17 +143,17 @@ public class ConfigTest {
                 Utils.immutableMap("topic", "mqtt/topic3", "source", TopicMapping.TopicType.LocalMqtt.toString(),
                         "target", TopicMapping.TopicType.IotCore.toString())));
 
-        kernel.getContext().waitForPublishQueueToClear();
+        testContext.getKernel().getContext().waitForPublishQueueToClear();
         assertThat(topicMapping.getMapping().size(), is(equalTo(3)));
         assertFalse(bridgeRestarted.await(2, TimeUnit.SECONDS));
     }
 
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_valid_mapping_provided_in_config_THEN_mapping_populated(ExtensionContext context)
-            throws Exception {
+    @TestWithMqtt3Broker
+    @WithKernel("config_with_mapping.yaml")
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_valid_mapping_provided_in_config_THEN_mapping_populated(Broker broker, ExtensionContext context) {
         ignoreExceptionOfType(context, MqttException.class);
-        startKernelWithConfig("config_with_mapping.yaml");
-        TopicMapping topicMapping = kernel.getContext().get(TopicMapping.class);
+
+        TopicMapping topicMapping = testContext.getKernel().getContext().get(TopicMapping.class);
 
         assertThat(() -> topicMapping.getMapping().size(), EventuallyLambdaMatcher.eventuallyEval(is(5)));
         Map<String, TopicMapping.MappingEntry> expectedMapping = new HashMap<>();
@@ -244,44 +176,44 @@ public class ConfigTest {
         assertEquals(expectedMapping, topicMapping.getMapping());
     }
 
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_empty_mqttTopicMapping_updated_THEN_mapping_not_updated(ExtensionContext context)
-            throws Exception {
+    @TestWithMqtt3Broker
+    @WithKernel("config.yaml")
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_empty_mqttTopicMapping_updated_THEN_mapping_not_updated(Broker broker, ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, MqttException.class);
-        startKernelWithConfig("config.yaml");
-        TopicMapping topicMapping = kernel.getContext().get(TopicMapping.class);
+
+        TopicMapping topicMapping = testContext.getKernel().getContext().get(TopicMapping.class);
         assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
 
-        kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
+        testContext.getKernel().locate(MQTTBridge.SERVICE_NAME).getConfig()
                 .lookupTopics(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_MQTT_TOPIC_MAPPING)
                 .replaceAndWait(Collections.emptyMap());
         // Block until subscriber has finished updating
-        kernel.getContext().waitForPublishQueueToClear();
+        testContext.getKernel().getContext().waitForPublishQueueToClear();
         assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
     }
 
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_mapping_updated_with_empty_THEN_mapping_removed(ExtensionContext context)
-            throws Exception {
+    @TestWithMqtt3Broker
+    @WithKernel("config_with_mapping.yaml")
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_mapping_updated_with_empty_THEN_mapping_removed(Broker broker, ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, MqttException.class);
-        startKernelWithConfig("config_with_mapping.yaml");
-        TopicMapping topicMapping = kernel.getContext().get(TopicMapping.class);
+
+        TopicMapping topicMapping = testContext.getKernel().getContext().get(TopicMapping.class);
 
         assertThat(() -> topicMapping.getMapping().size(), EventuallyLambdaMatcher.eventuallyEval(is(5)));
-        kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
+        testContext.getKernel().locate(MQTTBridge.SERVICE_NAME).getConfig()
                 .lookupTopics(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_MQTT_TOPIC_MAPPING)
                 .replaceAndWait(Collections.emptyMap());
         // Block until subscriber has finished updating
-        kernel.getContext().waitForPublishQueueToClear();
+        testContext.getKernel().getContext().waitForPublishQueueToClear();
         assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
     }
 
-    @Test
-    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_invalid_mqttTopicMapping_updated_THEN_mapping_not_updated(ExtensionContext context)
-            throws Exception {
+    @TestWithMqtt3Broker
+    @WithKernel("config.yaml")
+    void GIVEN_Greengrass_with_mqtt_bridge_WHEN_invalid_mqttTopicMapping_updated_THEN_mapping_not_updated(Broker broker, ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, InvalidFormatException.class);
-        startKernelWithConfig("config.yaml");
-        TopicMapping topicMapping = kernel.getContext().get(TopicMapping.class);
+
+        TopicMapping topicMapping = testContext.getKernel().getContext().get(TopicMapping.class);
         assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
 
         CountDownLatch bridgeErrored = new CountDownLatch(1);
@@ -290,10 +222,10 @@ public class ConfigTest {
                 bridgeErrored.countDown();
             }
         };
-        kernel.getContext().addGlobalStateChangeListener(listener);
+        testContext.getKernel().getContext().addGlobalStateChangeListener(listener);
 
         // Updating with invalid mapping (Providing type as Pubsub-Invalid)
-        Topics mappingConfigTopics = kernel.locate(MQTTBridge.SERVICE_NAME).getConfig()
+        Topics mappingConfigTopics = testContext.getKernel().locate(MQTTBridge.SERVICE_NAME).getConfig()
                 .lookupTopics(CONFIGURATION_CONFIG_KEY, BridgeConfig.KEY_MQTT_TOPIC_MAPPING);
 
         mappingConfigTopics.replaceAndWait(Utils.immutableMap("m1",
@@ -305,7 +237,7 @@ public class ConfigTest {
                         "target", TopicMapping.TopicType.IotCore.toString())));
 
         // Block until subscriber has finished updating
-        kernel.getContext().waitForPublishQueueToClear();
+        testContext.getKernel().getContext().waitForPublishQueueToClear();
         assertThat(topicMapping.getMapping().size(), is(equalTo(0)));
 
         assertTrue(bridgeErrored.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Refactor `ConfigTest` and `KeystoreTest` so that they use `@BridgeIntegrationTest` (introduced in https://github.com/aws-greengrass/aws-greengrass-mqtt-bridge/pull/96).  Functionally, everything is the same, just a lot of boilerplate cleanup

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
