### PR TITLE
feat: global mqtt5 config

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -34,12 +34,12 @@ import java.util.Objects;
 @EqualsAndHashCode
 @Builder
 @RequiredArgsConstructor
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class BridgeConfig {
     private static final Logger LOGGER = LogManager.getLogger(BridgeConfig.class);
 
     private static final JsonMapper OBJECT_MAPPER =
             JsonMapper.builder().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES).build();
+    private static final String INVALID_CONFIG_LOG_FORMAT_STRING = "Provided {} out of range. Defaulting to {}";
 
     static final String KEY_BROKER_SERVER_URI = "brokerServerUri"; // for backwards compatibility only
     public static final String KEY_BROKER_URI = "brokerUri";
@@ -145,14 +145,12 @@ public final class BridgeConfig {
                 KEY_BROKER_CLIENT, KEY_RECEIVE_MAXIMUM));
         if (receiveMaximum < MIN_RECEIVE_MAXIMUM) {
             LOGGER.atWarn().kv(KEY_RECEIVE_MAXIMUM, receiveMaximum)
-                    .log("Provided " + KEY_RECEIVE_MAXIMUM + " out of range. "
-                            + "Defaulting to " + MIN_RECEIVE_MAXIMUM);
+                    .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_RECEIVE_MAXIMUM, MIN_RECEIVE_MAXIMUM);
             return MIN_RECEIVE_MAXIMUM;
         }
         if (receiveMaximum > MAX_RECEIVE_MAXIMUM) {
             LOGGER.atWarn().kv(KEY_RECEIVE_MAXIMUM, receiveMaximum)
-                    .log("Provided " + KEY_RECEIVE_MAXIMUM + " out of range. "
-                            + "Defaulting to " + MAX_RECEIVE_MAXIMUM);
+                    .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_RECEIVE_MAXIMUM, MAX_RECEIVE_MAXIMUM);
             return MAX_RECEIVE_MAXIMUM;
         }
         return receiveMaximum;
@@ -167,14 +165,12 @@ public final class BridgeConfig {
         long maximumPacketSize = Coerce.toLong(maximumPacketSizeConf);
         if (maximumPacketSize < MIN_MAXIMUM_PACKET_SIZE) {
             LOGGER.atWarn().kv(KEY_MAXIMUM_PACKET_SIZE, maximumPacketSize)
-                    .log("Provided " + KEY_MAXIMUM_PACKET_SIZE + " out of range. "
-                            + "Defaulting to " + MIN_MAXIMUM_PACKET_SIZE);
+                    .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_MAXIMUM_PACKET_SIZE, MIN_MAXIMUM_PACKET_SIZE);
             return MIN_MAXIMUM_PACKET_SIZE;
         }
         if (maximumPacketSize > MAX_MAXIMUM_PACKET_SIZE) {
             LOGGER.atWarn().kv(KEY_MAXIMUM_PACKET_SIZE, maximumPacketSize)
-                    .log("Provided " + KEY_MAXIMUM_PACKET_SIZE + " out of range. "
-                            + "Defaulting to " + MAX_MAXIMUM_PACKET_SIZE);
+                    .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_MAXIMUM_PACKET_SIZE, MAX_MAXIMUM_PACKET_SIZE);
             return MAX_MAXIMUM_PACKET_SIZE;
         }
         return maximumPacketSize;
@@ -185,14 +181,12 @@ public final class BridgeConfig {
                 KEY_BROKER_CLIENT, KEY_SESSION_EXPIRY_INTERVAL));
         if (sessionExpiryInterval < MIN_SESSION_EXPIRY_INTERVAL) {
             LOGGER.atWarn().kv(KEY_SESSION_EXPIRY_INTERVAL, sessionExpiryInterval)
-                    .log("Provided " + KEY_SESSION_EXPIRY_INTERVAL + " out of range. "
-                            + "Defaulting to " + MIN_SESSION_EXPIRY_INTERVAL);
+                    .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_SESSION_EXPIRY_INTERVAL, MIN_SESSION_EXPIRY_INTERVAL);
             return MIN_SESSION_EXPIRY_INTERVAL;
         }
         if (sessionExpiryInterval > MAX_SESSION_EXPIRY_INTERVAL) {
             LOGGER.atWarn().kv(KEY_SESSION_EXPIRY_INTERVAL, sessionExpiryInterval)
-                    .log("Provided " + KEY_SESSION_EXPIRY_INTERVAL + " out of range. "
-                            + "Defaulting to " + MAX_SESSION_EXPIRY_INTERVAL);
+                    .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_SESSION_EXPIRY_INTERVAL, MAX_SESSION_EXPIRY_INTERVAL);
             return MAX_SESSION_EXPIRY_INTERVAL;
         }
         return sessionExpiryInterval;

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -47,17 +47,20 @@ public final class BridgeConfig {
     static final String KEY_BROKER_CLIENT = "brokerClient";
     static final String KEY_VERSION = "version";
     static final String KEY_NO_LOCAL = "noLocal";
+    static final String KEY_RECEIVE_MAXIMUM = "receiveMaximum";
 
     private static final String DEFAULT_BROKER_URI = "ssl://localhost:8883";
     private static final String DEFAULT_CLIENT_ID = "mqtt-bridge-" + Utils.generateRandomString(11);
     private static final MqttVersion DEFAULT_MQTT_VERSION = MqttVersion.MQTT3;
     private static final boolean DEFAULT_NO_LOCAL = false;
+    private static final int DEFAULT_RECEIVE_MAXIMUM = 65_535;
 
     private final URI brokerUri;
     private final String clientId;
     private final Map<String, TopicMapping.MappingEntry> topicMapping;
     private final MqttVersion mqttVersion;
     private final boolean noLocal;
+    private final int receiveMaximum;
 
 
     /**
@@ -75,6 +78,7 @@ public final class BridgeConfig {
                 .topicMapping(getTopicMapping(configurationTopics))
                 .mqttVersion(getMqttVersion(configurationTopics))
                 .noLocal(getNoLocal(configurationTopics))
+                .receiveMaximum(getReceiveMaximum(configurationTopics))
                 .build();
     }
 
@@ -117,6 +121,18 @@ public final class BridgeConfig {
     private static boolean getNoLocal(Topics configurationTopics) {
         return Coerce.toBoolean(configurationTopics.findOrDefault(DEFAULT_NO_LOCAL,
                 KEY_BROKER_CLIENT, KEY_NO_LOCAL));
+    }
+
+    private static int getReceiveMaximum(Topics configurationTopics) {
+        int receiveMaximum = Coerce.toInt(configurationTopics.findOrDefault(DEFAULT_RECEIVE_MAXIMUM,
+                KEY_BROKER_CLIENT, KEY_RECEIVE_MAXIMUM));
+        if (receiveMaximum < 1 || receiveMaximum > DEFAULT_RECEIVE_MAXIMUM) {
+            LOGGER.atWarn().kv(KEY_RECEIVE_MAXIMUM, receiveMaximum)
+                    .log("Provided " + KEY_RECEIVE_MAXIMUM + " out of range. "
+                            + "Defaulting to " + DEFAULT_RECEIVE_MAXIMUM);
+            return DEFAULT_RECEIVE_MAXIMUM;
+        }
+        return receiveMaximum;
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 @EqualsAndHashCode
 @Builder
 @RequiredArgsConstructor
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class BridgeConfig {
     private static final Logger LOGGER = LogManager.getLogger(BridgeConfig.class);
 

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -57,6 +57,8 @@ public final class BridgeConfig {
     private static final int DEFAULT_RECEIVE_MAXIMUM = 65_535;
     private static final Long DEFAULT_MAXIMUM_PACKET_SIZE = null;
 
+    private static final int MIN_RECEIVE_MAXIMUM = 1;
+    private static final int MAX_RECEIVE_MAXIMUM = 65535;
     private static final long MIN_MAXIMUM_PACKET_SIZE = 1;
     private static final long MAX_MAXIMUM_PACKET_SIZE = 4294967295L;
 
@@ -133,11 +135,17 @@ public final class BridgeConfig {
     private static int getReceiveMaximum(Topics configurationTopics) {
         int receiveMaximum = Coerce.toInt(configurationTopics.findOrDefault(DEFAULT_RECEIVE_MAXIMUM,
                 KEY_BROKER_CLIENT, KEY_RECEIVE_MAXIMUM));
-        if (receiveMaximum < 1 || receiveMaximum > DEFAULT_RECEIVE_MAXIMUM) {
+        if (receiveMaximum < MIN_RECEIVE_MAXIMUM) {
             LOGGER.atWarn().kv(KEY_RECEIVE_MAXIMUM, receiveMaximum)
                     .log("Provided " + KEY_RECEIVE_MAXIMUM + " out of range. "
-                            + "Defaulting to " + DEFAULT_RECEIVE_MAXIMUM);
-            return DEFAULT_RECEIVE_MAXIMUM;
+                            + "Defaulting to " + MIN_RECEIVE_MAXIMUM);
+            return MIN_RECEIVE_MAXIMUM;
+        }
+        if (receiveMaximum > MAX_RECEIVE_MAXIMUM) {
+            LOGGER.atWarn().kv(KEY_RECEIVE_MAXIMUM, receiveMaximum)
+                    .log("Provided " + KEY_RECEIVE_MAXIMUM + " out of range. "
+                            + "Defaulting to " + MAX_RECEIVE_MAXIMUM);
+            return MAX_RECEIVE_MAXIMUM;
         }
         return receiveMaximum;
     }

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.net.URI;
 import java.util.Collections;
@@ -34,6 +36,7 @@ class BridgeConfigTest {
     private static final String DEFAULT_CLIENT_ID_PREFIX = "mqtt-bridge-";
     private static final MqttVersion DEFAULT_MQTT_VERSION = MqttVersion.MQTT3;
     private static final boolean DEFAULT_NO_LOCAL = false;
+    private static final int DEFAULT_RECEIVE_MAXIMUM = 65535;
     private static final String BROKER_URI = "tcp://localhost:8883";
     private static final String BROKER_SERVER_URI = "tcp://localhost:8884";
     private static final String MALFORMED_BROKER_URI = "tcp://ma]formed.uri:8883";
@@ -60,6 +63,7 @@ class BridgeConfigTest {
                 .topicMapping(Collections.emptyMap())
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -76,6 +80,7 @@ class BridgeConfigTest {
                 .topicMapping(Collections.emptyMap())
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -93,6 +98,7 @@ class BridgeConfigTest {
                 .topicMapping(Collections.emptyMap())
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -109,6 +115,7 @@ class BridgeConfigTest {
                 .topicMapping(Collections.emptyMap())
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -131,6 +138,7 @@ class BridgeConfigTest {
                 .topicMapping(Collections.emptyMap())
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .build();
         assertEquals(expectedConfig, config);
     }
@@ -158,6 +166,7 @@ class BridgeConfigTest {
                 .topicMapping(expectedEntries)
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -190,6 +199,7 @@ class BridgeConfigTest {
                 .topicMapping(Collections.emptyMap())
                 .mqttVersion(MqttVersion.MQTT5)
                 .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -205,6 +215,7 @@ class BridgeConfigTest {
                 .topicMapping(Collections.emptyMap())
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -221,6 +232,43 @@ class BridgeConfigTest {
                 .topicMapping(Collections.emptyMap())
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(true)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 1234, DEFAULT_RECEIVE_MAXIMUM})
+    void GIVEN_receiveMaximum_provided_WHEN_bridge_config_created_THEN_receiveMaximum_used(int receiveMaximum) throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_RECEIVE_MAXIMUM).dflt(receiveMaximum);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(receiveMaximum)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1, DEFAULT_RECEIVE_MAXIMUM + 1})
+    void GIVEN_invalid_receiveMaximum_provided_WHEN_bridge_config_created_THEN_receiveMaximum_used(int invalidReceiveMaximum) throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_RECEIVE_MAXIMUM).dflt(invalidReceiveMaximum);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -38,6 +38,7 @@ class BridgeConfigTest {
     private static final boolean DEFAULT_NO_LOCAL = false;
     private static final int DEFAULT_RECEIVE_MAXIMUM = 65535;
     private static final Long DEFAULT_MAXIMUM_PACKET_SIZE = null;
+    private static final long DEFAULT_SESSION_EXPIRY_INTERVAL = 4_294_967_295L;
     private static final String BROKER_URI = "tcp://localhost:8883";
     private static final String BROKER_SERVER_URI = "tcp://localhost:8884";
     private static final String MALFORMED_BROKER_URI = "tcp://ma]formed.uri:8883";
@@ -66,6 +67,7 @@ class BridgeConfigTest {
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -84,6 +86,7 @@ class BridgeConfigTest {
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -103,6 +106,7 @@ class BridgeConfigTest {
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -121,6 +125,7 @@ class BridgeConfigTest {
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -145,6 +150,7 @@ class BridgeConfigTest {
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertEquals(expectedConfig, config);
     }
@@ -174,6 +180,7 @@ class BridgeConfigTest {
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -208,6 +215,7 @@ class BridgeConfigTest {
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -225,6 +233,7 @@ class BridgeConfigTest {
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -243,6 +252,7 @@ class BridgeConfigTest {
                 .noLocal(true)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -262,6 +272,7 @@ class BridgeConfigTest {
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(receiveMaximum)
                 .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -281,6 +292,7 @@ class BridgeConfigTest {
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(65535)
                 .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -300,6 +312,7 @@ class BridgeConfigTest {
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(1)
                 .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -319,6 +332,7 @@ class BridgeConfigTest {
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .maximumPacketSize(maximumPacketSize)
+                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -338,6 +352,7 @@ class BridgeConfigTest {
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .maximumPacketSize(1L)
+                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -357,6 +372,67 @@ class BridgeConfigTest {
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .maximumPacketSize(4294967295L)
+                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {0, 1234, 4294967295L})
+    void GIVEN_sessionExpiryInterval_provided_WHEN_bridge_config_created_THEN_sessionExpiryInterval_used(long sessionExpiryInterval) throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_SESSION_EXPIRY_INTERVAL).dflt(sessionExpiryInterval);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .sessionExpiryInterval(sessionExpiryInterval)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {-1L, Long.MIN_VALUE})
+    void GIVEN_too_small_sessionExpiryInterval_provided_WHEN_bridge_config_created_THEN_min_sessionExpiryInterval_used(long invalidSessionExpiryInterval) throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_SESSION_EXPIRY_INTERVAL).dflt(invalidSessionExpiryInterval);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .sessionExpiryInterval(0L)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {4_294_967_296L, Long.MAX_VALUE})
+    void GIVEN_too_large_sessionExpiryInterval_provided_WHEN_bridge_config_created_THEN_max_sessionExpiryInterval_used(long invalidSessionExpiryInterval) throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_SESSION_EXPIRY_INTERVAL).dflt(invalidSessionExpiryInterval);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .sessionExpiryInterval(4_294_967_295L)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -268,8 +268,8 @@ class BridgeConfigTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {0, -1, DEFAULT_RECEIVE_MAXIMUM + 1})
-    void GIVEN_invalid_receiveMaximum_provided_WHEN_bridge_config_created_THEN_receiveMaximum_used(int invalidReceiveMaximum) throws InvalidConfigurationException {
+    @ValueSource(ints = {DEFAULT_RECEIVE_MAXIMUM + 1, Integer.MAX_VALUE})
+    void GIVEN_too_large_receiveMaximum_provided_WHEN_bridge_config_created_THEN_max_receiveMaximum_used(int invalidReceiveMaximum) throws InvalidConfigurationException {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_RECEIVE_MAXIMUM).dflt(invalidReceiveMaximum);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
@@ -279,7 +279,26 @@ class BridgeConfigTest {
                 .topicMapping(Collections.emptyMap())
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .receiveMaximum(65535)
+                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1, Integer.MIN_VALUE})
+    void GIVEN_too_small_receiveMaximum_provided_WHEN_bridge_config_created_THEN_min_receiveMaximum_used(int invalidReceiveMaximum) throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_RECEIVE_MAXIMUM).dflt(invalidReceiveMaximum);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(1)
                 .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
                 .build();
         assertDefaultClientId(config);

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -33,6 +33,7 @@ class BridgeConfigTest {
     private static final String DEFAULT_BROKER_URI = "ssl://localhost:8883";
     private static final String DEFAULT_CLIENT_ID_PREFIX = "mqtt-bridge-";
     private static final MqttVersion DEFAULT_MQTT_VERSION = MqttVersion.MQTT3;
+    private static final boolean DEFAULT_NO_LOCAL = false;
     private static final String BROKER_URI = "tcp://localhost:8883";
     private static final String BROKER_SERVER_URI = "tcp://localhost:8884";
     private static final String MALFORMED_BROKER_URI = "tcp://ma]formed.uri:8883";
@@ -53,12 +54,13 @@ class BridgeConfigTest {
     @Test
     void GIVEN_empty_config_WHEN_bridge_config_created_THEN_defaults_used() throws InvalidConfigurationException {
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = new BridgeConfig(
-                URI.create(DEFAULT_BROKER_URI),
-                config.getClientId(),
-                Collections.emptyMap(),
-                DEFAULT_MQTT_VERSION
-        );
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
     }
@@ -68,12 +70,13 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_URI).dflt(BROKER_URI);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = new BridgeConfig(
-                URI.create(BROKER_URI),
-                config.getClientId(),
-                Collections.emptyMap(),
-                DEFAULT_MQTT_VERSION
-        );
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
     }
@@ -84,12 +87,13 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_URI).dflt(BROKER_URI);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = new BridgeConfig(
-                URI.create(BROKER_URI),
-                config.getClientId(),
-                Collections.emptyMap(),
-                DEFAULT_MQTT_VERSION
-        );
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
     }
@@ -99,12 +103,13 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_SERVER_URI).dflt(BROKER_SERVER_URI);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = new BridgeConfig(
-                URI.create(BROKER_SERVER_URI),
-                config.getClientId(),
-                Collections.emptyMap(),
-                DEFAULT_MQTT_VERSION
-        );
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(BROKER_SERVER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
     }
@@ -120,12 +125,13 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_CLIENT_ID).dflt(CLIENT_ID);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = new BridgeConfig(
-                URI.create(DEFAULT_BROKER_URI),
-                CLIENT_ID,
-                Collections.emptyMap(),
-                DEFAULT_MQTT_VERSION
-        );
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+                .clientId(CLIENT_ID)
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .build();
         assertEquals(expectedConfig, config);
     }
 
@@ -146,12 +152,13 @@ class BridgeConfigTest {
         expectedEntries.put("m3", new TopicMapping.MappingEntry("mqtt/topic3", TopicMapping.TopicType.LocalMqtt, TopicMapping.TopicType.IotCore));
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = new BridgeConfig(
-                URI.create(DEFAULT_BROKER_URI),
-                config.getClientId(),
-                expectedEntries,
-                DEFAULT_MQTT_VERSION
-        );
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(expectedEntries)
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
     }
@@ -177,12 +184,13 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_VERSION).dflt("mqtt5");
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = new BridgeConfig(
-                URI.create(DEFAULT_BROKER_URI),
-                config.getClientId(),
-                Collections.emptyMap(),
-                MqttVersion.MQTT5
-        );
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(MqttVersion.MQTT5)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
     }
@@ -191,12 +199,29 @@ class BridgeConfigTest {
     void GIVEN_invalid_mqtt_version_config_WHEN_bridge_config_created_THEN_default_version_used() throws InvalidConfigurationException {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_VERSION).dflt("INVALID_VALUE");
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = new BridgeConfig(
-                URI.create(DEFAULT_BROKER_URI),
-                config.getClientId(),
-                Collections.emptyMap(),
-                DEFAULT_MQTT_VERSION
-        );
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @Test
+    void GIVEN_noLocal_provided_WHEN_bridge_config_created_THEN_noLocal_used() throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_NO_LOCAL).dflt(true);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(true)
+                .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
     }

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -37,6 +37,7 @@ class BridgeConfigTest {
     private static final MqttVersion DEFAULT_MQTT_VERSION = MqttVersion.MQTT3;
     private static final boolean DEFAULT_NO_LOCAL = false;
     private static final int DEFAULT_RECEIVE_MAXIMUM = 65535;
+    private static final Long DEFAULT_MAXIMUM_PACKET_SIZE = null;
     private static final String BROKER_URI = "tcp://localhost:8883";
     private static final String BROKER_SERVER_URI = "tcp://localhost:8884";
     private static final String MALFORMED_BROKER_URI = "tcp://ma]formed.uri:8883";
@@ -64,6 +65,7 @@ class BridgeConfigTest {
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -81,6 +83,7 @@ class BridgeConfigTest {
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -99,6 +102,7 @@ class BridgeConfigTest {
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -116,6 +120,7 @@ class BridgeConfigTest {
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -139,6 +144,7 @@ class BridgeConfigTest {
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
                 .build();
         assertEquals(expectedConfig, config);
     }
@@ -167,6 +173,7 @@ class BridgeConfigTest {
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -200,6 +207,7 @@ class BridgeConfigTest {
                 .mqttVersion(MqttVersion.MQTT5)
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -216,6 +224,7 @@ class BridgeConfigTest {
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -233,6 +242,7 @@ class BridgeConfigTest {
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(true)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -251,6 +261,7 @@ class BridgeConfigTest {
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(receiveMaximum)
+                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -269,6 +280,64 @@ class BridgeConfigTest {
                 .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {1, 1234, 4294967295L})
+    void GIVEN_maximumPacketSize_provided_WHEN_bridge_config_created_THEN_maximumPacketSize_used(long maximumPacketSize) throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MAXIMUM_PACKET_SIZE).dflt(maximumPacketSize);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(maximumPacketSize)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {0L, -1L, Long.MIN_VALUE})
+    void GIVEN_too_small_maximumPacketSize_provided_WHEN_bridge_config_created_THEN_min_maximumPacketSize_used(long invalidMaximumPacketSize) throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MAXIMUM_PACKET_SIZE).dflt(invalidMaximumPacketSize);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(1L)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {4294967296L, Long.MAX_VALUE})
+    void GIVEN_too_large_maximumPacketSize_provided_WHEN_bridge_config_created_THEN_max_maximumPacketSize_used(long invalidMaximumPacketSize) throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MAXIMUM_PACKET_SIZE).dflt(invalidMaximumPacketSize);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BridgeConfig.builder()
+                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+                .clientId(config.getClientId())
+                .topicMapping(Collections.emptyMap())
+                .mqttVersion(DEFAULT_MQTT_VERSION)
+                .noLocal(DEFAULT_NO_LOCAL)
+                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+                .maximumPacketSize(4294967295L)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Adds the following global mqtt5 configuration options:

```
brokerClient.noLocal = false
brokerClient.receiveMaximum = 65535  (range 1 to 65535)
brokerClient.maximumPacketSize = null (range 1 to 4294967295)
brokerClient.sessionExpiryInterval = 4294967295 (range 0 to 4294967295)
```

⚠️ If configured numerical values are out of range, they will be clamped to the min/max value.  e.g. 4294967296 becomes 4294967295

Per-route config will be added in a subsequent PR

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
