### PR TITLE
feat: per-route mqtt5 config

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.mqtt.bridge.BridgeConfig;
 import com.aws.greengrass.mqtt.bridge.MQTTBridge;
 import com.aws.greengrass.mqtt.bridge.TopicMapping;
+import com.aws.greengrass.mqtt.bridge.model.Mqtt5RouteOptions;
 import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.github.grantwest.eventually.EventuallyLambdaMatcher;
@@ -174,6 +175,16 @@ public class ConfigTest {
                         TopicMapping.TopicType.IotCore, "a-prefix"));
 
         assertEquals(expectedMapping, topicMapping.getMapping());
+
+        Map<String, Mqtt5RouteOptions> expectedRouteOptions = new HashMap<>();
+        expectedRouteOptions.put("mapping1", Mqtt5RouteOptions.builder().noLocal(true).retainAsPublished(false).build());
+        expectedRouteOptions.put("mapping2", Mqtt5RouteOptions.builder().noLocal(false).retainAsPublished(true).build());
+        expectedRouteOptions.put("mappingNotInMqttTopicMapping", Mqtt5RouteOptions.builder().noLocal(true).retainAsPublished(true).build());
+
+        Map<String, Mqtt5RouteOptions> actualRouteOptions =
+                testContext.getKernel().getContext().get(MQTTBridge.class).getBridgeConfig().getMqtt5RouteOptions();
+
+        assertEquals(expectedRouteOptions, actualRouteOptions);
     }
 
     @TestWithMqtt3Broker

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
@@ -178,7 +178,6 @@ public class ConfigTest {
 
         Map<String, Mqtt5RouteOptions> expectedRouteOptions = new HashMap<>();
         expectedRouteOptions.put("mapping1", Mqtt5RouteOptions.builder().noLocal(true).retainAsPublished(false).build());
-        expectedRouteOptions.put("mapping2", Mqtt5RouteOptions.builder().noLocal(false).retainAsPublished(true).build());
         expectedRouteOptions.put("mappingNotInMqttTopicMapping", Mqtt5RouteOptions.builder().noLocal(true).retainAsPublished(true).build());
 
         Map<String, Mqtt5RouteOptions> actualRouteOptions =

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/config_with_mapping.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/config_with_mapping.yaml
@@ -2,6 +2,13 @@ services:
   aws.greengrass.clientdevices.mqtt.Bridge:
     configuration:
       brokerUri: 'tcp://localhost:8883'
+      mqtt5RouteOptions:
+        mapping1:
+          noLocal: true
+          retainAsPublished: false
+        mapping2:
+        mappingNotInMqttTopicMapping:
+          noLocal: true
       mqttTopicMapping:
         mapping1:
           topic: topic/to/map/from/local/to/cloud

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/config_with_mapping.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/config_with_mapping.yaml
@@ -9,6 +9,7 @@ services:
         mapping2:
         mappingNotInMqttTopicMapping:
           noLocal: true
+          UNSUPPORTED_PROPERTY: must not error
       mqttTopicMapping:
         mapping1:
           topic: topic/to/map/from/local/to/cloud

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -9,10 +9,12 @@ import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.mqtt.bridge.model.InvalidConfigurationException;
+import com.aws.greengrass.mqtt.bridge.model.Mqtt5RouteOptions;
 import com.aws.greengrass.mqtt.bridge.model.MqttVersion;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import lombok.Builder;
@@ -32,19 +34,22 @@ import java.util.Objects;
 @Getter
 @ToString
 @EqualsAndHashCode
-@Builder
+@Builder(toBuilder = true)
 @RequiredArgsConstructor
 public final class BridgeConfig {
     private static final Logger LOGGER = LogManager.getLogger(BridgeConfig.class);
-
-    private static final JsonMapper OBJECT_MAPPER =
-            JsonMapper.builder().enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES).build();
+    private static final JsonMapper OBJECT_MAPPER = JsonMapper.builder()
+            .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
+            // allow bridge version upgrade/downgrade when new properties are added
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .build();
     private static final String INVALID_CONFIG_LOG_FORMAT_STRING = "Provided {} out of range. Defaulting to {}";
 
     static final String KEY_BROKER_SERVER_URI = "brokerServerUri"; // for backwards compatibility only
     public static final String KEY_BROKER_URI = "brokerUri";
     public static final String KEY_CLIENT_ID = "clientId";
     public static final String KEY_MQTT_TOPIC_MAPPING = "mqttTopicMapping";
+    static final String KEY_MQTT_5_ROUTE_OPTIONS = "mqtt5RouteOptions";
     static final String KEY_BROKER_CLIENT = "brokerClient";
     static final String KEY_VERSION = "version";
     static final String KEY_NO_LOCAL = "noLocal";
@@ -71,6 +76,7 @@ public final class BridgeConfig {
     private final URI brokerUri;
     private final String clientId;
     private final Map<String, TopicMapping.MappingEntry> topicMapping;
+    private final Map<String, Mqtt5RouteOptions> mqtt5RouteOptions;
     private final MqttVersion mqttVersion;
     private final boolean noLocal;
     private final int receiveMaximum;
@@ -91,6 +97,7 @@ public final class BridgeConfig {
                 .brokerUri(getBrokerUri(configurationTopics))
                 .clientId(getClientId(configurationTopics))
                 .topicMapping(getTopicMapping(configurationTopics))
+                .mqtt5RouteOptions(getMqtt5RouteOptions(configurationTopics))
                 .mqttVersion(getMqttVersion(configurationTopics))
                 .noLocal(getNoLocal(configurationTopics))
                 .receiveMaximum(getReceiveMaximum(configurationTopics))
@@ -126,6 +133,28 @@ public final class BridgeConfig {
         } catch (IllegalArgumentException e) {
             throw new InvalidConfigurationException("Malformed " + KEY_MQTT_TOPIC_MAPPING, e);
         }
+    }
+
+    private static Map<String, Mqtt5RouteOptions> getMqtt5RouteOptions(Topics configurationTopics)
+            throws InvalidConfigurationException {
+        Map<String, Mqtt5RouteOptions> routeOptions;
+        try {
+            routeOptions = OBJECT_MAPPER.convertValue(
+                    configurationTopics.lookupTopics(KEY_MQTT_5_ROUTE_OPTIONS).toPOJO(),
+                    new TypeReference<Map<String, Mqtt5RouteOptions>>() {
+                    });
+        } catch (IllegalArgumentException e) {
+            throw new InvalidConfigurationException("Malformed " + KEY_MQTT_5_ROUTE_OPTIONS, e);
+        }
+
+        // if an empty mapping is provided, use default values rather than nothing.
+        for (Map.Entry<String, Mqtt5RouteOptions> e : routeOptions.entrySet()) {
+            if (e.getValue() == null) {
+                e.setValue(new Mqtt5RouteOptions());
+            }
+        }
+
+        return routeOptions;
     }
 
     private static MqttVersion getMqttVersion(Topics configurationTopics) {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -27,6 +27,7 @@ import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.util.BatchedSubscriber;
 import com.aws.greengrass.util.Utils;
+import lombok.Getter;
 
 import java.io.IOException;
 import java.security.KeyStoreException;
@@ -53,6 +54,7 @@ public class MQTTBridge extends PluginService {
     private MessageClient<MqttMessage> localMqttClient;
     private PubSubClient pubSubClient;
     private IoTCoreClient ioTCoreClient;
+    @Getter // for unit testing
     private BridgeConfig bridgeConfig;
 
 

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/model/Mqtt5RouteOptions.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/model/Mqtt5RouteOptions.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqtt.bridge.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Mqtt5RouteOptions {
+    @Builder.Default
+    boolean noLocal = false;
+    @Builder.Default
+    boolean retainAsPublished = true;
+}

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -344,12 +344,11 @@ class BridgeConfigTest {
         topics.lookupTopics(BridgeConfig.KEY_MQTT_5_ROUTE_OPTIONS).replaceAndWait(
                 Utils.immutableMap(
                         "m1", Utils.immutableMap("noLocal", "true", "retainAsPublished",  "false"),
-                        "m2", Collections.emptyMap(),
+                        "m2", null,
                         "m3", Utils.immutableMap("noLocal", "true")));
 
         Map<String, Mqtt5RouteOptions> expectedEntries = new HashMap<>();
         expectedEntries.put("m1", Mqtt5RouteOptions.builder().noLocal(true).retainAsPublished(false).build());
-        expectedEntries.put("m2", Mqtt5RouteOptions.builder().noLocal(false).retainAsPublished(true).build());
         expectedEntries.put("m3", Mqtt5RouteOptions.builder().noLocal(true).retainAsPublished(true).build());
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -9,6 +9,7 @@ import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.mqtt.bridge.model.InvalidConfigurationException;
+import com.aws.greengrass.mqtt.bridge.model.Mqtt5RouteOptions;
 import com.aws.greengrass.mqtt.bridge.model.MqttVersion;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.Utils;
@@ -44,6 +45,17 @@ class BridgeConfigTest {
     private static final String MALFORMED_BROKER_URI = "tcp://ma]formed.uri:8883";
     private static final String CLIENT_ID = "clientId";
 
+    private static final BridgeConfig BASE_CONFIG = BridgeConfig.builder()
+            .brokerUri(URI.create(DEFAULT_BROKER_URI))
+            .topicMapping(Collections.emptyMap())
+            .mqtt5RouteOptions(Collections.emptyMap())
+            .mqttVersion(DEFAULT_MQTT_VERSION)
+            .noLocal(DEFAULT_NO_LOCAL)
+            .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
+            .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
+            .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
+            .build();
+
     Topics topics;
 
     @BeforeEach
@@ -59,15 +71,8 @@ class BridgeConfigTest {
     @Test
     void GIVEN_empty_config_WHEN_bridge_config_created_THEN_defaults_used() throws InvalidConfigurationException {
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
-                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
-                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
-                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -78,15 +83,9 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_URI).dflt(BROKER_URI);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .brokerUri(URI.create(BROKER_URI))
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
-                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
-                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -98,15 +97,9 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_URI).dflt(BROKER_URI);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .brokerUri(URI.create(BROKER_URI))
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
-                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
-                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -117,15 +110,9 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_SERVER_URI).dflt(BROKER_SERVER_URI);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .brokerUri(URI.create(BROKER_SERVER_URI))
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
-                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
-                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -142,15 +129,8 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_CLIENT_ID).dflt(CLIENT_ID);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
-                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(CLIENT_ID)
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
-                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
-                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertEquals(expectedConfig, config);
     }
@@ -172,15 +152,9 @@ class BridgeConfigTest {
         expectedEntries.put("m3", new TopicMapping.MappingEntry("mqtt/topic3", TopicMapping.TopicType.LocalMqtt, TopicMapping.TopicType.IotCore));
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
-                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(config.getClientId())
                 .topicMapping(expectedEntries)
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
-                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
-                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -207,15 +181,9 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_VERSION).dflt("mqtt5");
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
-                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
                 .mqttVersion(MqttVersion.MQTT5)
-                .noLocal(DEFAULT_NO_LOCAL)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
-                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
-                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -225,15 +193,8 @@ class BridgeConfigTest {
     void GIVEN_invalid_mqtt_version_config_WHEN_bridge_config_created_THEN_default_version_used() throws InvalidConfigurationException {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_VERSION).dflt("INVALID_VALUE");
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
-                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
-                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
-                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -244,15 +205,9 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_NO_LOCAL).dflt(true);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
-                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
                 .noLocal(true)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
-                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
-                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -264,15 +219,9 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_RECEIVE_MAXIMUM).dflt(receiveMaximum);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
-                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(receiveMaximum)
-                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
-                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -284,15 +233,9 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_RECEIVE_MAXIMUM).dflt(invalidReceiveMaximum);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
-                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(65535)
-                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
-                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -304,15 +247,9 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_RECEIVE_MAXIMUM).dflt(invalidReceiveMaximum);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
-                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
                 .receiveMaximum(1)
-                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
-                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -324,15 +261,9 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MAXIMUM_PACKET_SIZE).dflt(maximumPacketSize);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
-                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .maximumPacketSize(maximumPacketSize)
-                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -344,15 +275,9 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MAXIMUM_PACKET_SIZE).dflt(invalidMaximumPacketSize);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
-                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .maximumPacketSize(1L)
-                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -364,15 +289,9 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MAXIMUM_PACKET_SIZE).dflt(invalidMaximumPacketSize);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
-                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
                 .maximumPacketSize(4294967295L)
-                .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
@@ -384,14 +303,8 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_SESSION_EXPIRY_INTERVAL).dflt(sessionExpiryInterval);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
-                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
-                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
                 .sessionExpiryInterval(sessionExpiryInterval)
                 .build();
         assertDefaultClientId(config);
@@ -404,14 +317,8 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_SESSION_EXPIRY_INTERVAL).dflt(invalidSessionExpiryInterval);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
-                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
-                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
                 .sessionExpiryInterval(0L)
                 .build();
         assertDefaultClientId(config);
@@ -424,18 +331,50 @@ class BridgeConfigTest {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_SESSION_EXPIRY_INTERVAL).dflt(invalidSessionExpiryInterval);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
-        BridgeConfig expectedConfig = BridgeConfig.builder()
-                .brokerUri(URI.create(DEFAULT_BROKER_URI))
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(config.getClientId())
-                .topicMapping(Collections.emptyMap())
-                .mqttVersion(DEFAULT_MQTT_VERSION)
-                .noLocal(DEFAULT_NO_LOCAL)
-                .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
-                .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
                 .sessionExpiryInterval(4_294_967_295L)
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
+    }
+
+    @Test
+    void GIVEN_mqtt5_route_options_WHEN_bridge_config_created_THEN_mqtt5_route_options_used() throws InvalidConfigurationException {
+        topics.lookupTopics(BridgeConfig.KEY_MQTT_5_ROUTE_OPTIONS).replaceAndWait(
+                Utils.immutableMap(
+                        "m1", Utils.immutableMap("noLocal", "true", "retainAsPublished",  "false"),
+                        "m2", Collections.emptyMap(),
+                        "m3", Utils.immutableMap("noLocal", "true")));
+
+        Map<String, Mqtt5RouteOptions> expectedEntries = new HashMap<>();
+        expectedEntries.put("m1", Mqtt5RouteOptions.builder().noLocal(true).retainAsPublished(false).build());
+        expectedEntries.put("m2", Mqtt5RouteOptions.builder().noLocal(false).retainAsPublished(true).build());
+        expectedEntries.put("m3", Mqtt5RouteOptions.builder().noLocal(true).retainAsPublished(true).build());
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
+                .clientId(config.getClientId())
+                .mqtt5RouteOptions(expectedEntries)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @Test
+    void GIVEN_invalid_mqtt5_route_options_WHEN_bridge_config_created_THEN_exception_thrown() {
+        String invalidSource = "INVALID_SOURCE";
+
+        topics.lookupTopics(BridgeConfig.KEY_MQTT_TOPIC_MAPPING).replaceAndWait(
+                Utils.immutableMap(
+                        "m1",
+                        Utils.immutableMap("topic", "mqtt/topic", "source", invalidSource, "target", TopicMapping.TopicType.IotCore.toString()),
+                        "m2",
+                        Utils.immutableMap("topic", "mqtt/topic2", "source", TopicMapping.TopicType.LocalMqtt.toString(), "target", TopicMapping.TopicType.Pubsub.toString()),
+                        "m3",
+                        Utils.immutableMap("topic", "mqtt/topic3", "source", TopicMapping.TopicType.LocalMqtt.toString(), "target", TopicMapping.TopicType.IotCore.toString())));
+
+        assertThrows(InvalidConfigurationException.class, () -> BridgeConfig.fromTopics(topics));
     }
 
     private void assertDefaultClientId(BridgeConfig config) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Adds mqtt5-specific route options via a new `mqtt5RouteOptions` config.  This config is a mapping from route name to properties, similar to the existing `mqttTopicMapping` config option.
```
"mqtt5RouteOptions": {
    "route1": {
        "noLocal": false,
        "retainAsPublished": true
    },
    "route2": {
        ...
    },
    ...
}
```

Also configures objectmapper to allow unrecognized properties, so mqtt5 route config can grow over time.

⚠️ As discovered through this PR, we must not add fields to `mqttTopicMappings` as this will break backwards compatibility, due to objectmapper for current/previous bridge versions not being configured to allow unrecognized values.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
