### PR TITLE
feat: support mqtt5 in iot core client

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/model/MqttMessage.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/model/MqttMessage.java
@@ -29,6 +29,26 @@ public class MqttMessage implements Message {
     Long messageExpiryIntervalSeconds;
 
     /**
+     * Convert spooler mqtt v5 message to an MqttMessage.
+     *
+     * @param message spooler v5 message
+     * @return mqtt message
+     */
+    public static MqttMessage fromSpoolerV5Model(@NonNull Publish message) {
+        return MqttMessage.builder()
+                .topic(message.getTopic())
+                .payload(message.getPayload())
+                .retain(message.isRetain())
+                .payloadFormat(message.getPayloadFormat())
+                .contentType(message.getContentType())
+                .responseTopic(message.getResponseTopic())
+                .correlationData(message.getCorrelationData())
+                .userProperties(message.getUserProperties())
+                .messageExpiryIntervalSeconds(message.getMessageExpiryIntervalSeconds())
+                .build();
+    }
+
+    /**
      * Convert AWS SDK CRT message to an MqttMessage.
      *
      * @param message crt message

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClientTest.java
@@ -7,9 +7,12 @@ package com.aws.greengrass.mqtt.bridge.clients;
 
 import com.aws.greengrass.mqtt.bridge.model.Message;
 import com.aws.greengrass.mqttclient.MqttClient;
-import com.aws.greengrass.mqttclient.PublishRequest;
-import com.aws.greengrass.mqttclient.SubscribeRequest;
-import com.aws.greengrass.mqttclient.UnsubscribeRequest;
+import com.aws.greengrass.mqttclient.MqttRequestException;
+import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
+import com.aws.greengrass.mqttclient.v5.Publish;
+import com.aws.greengrass.mqttclient.v5.Subscribe;
+import com.aws.greengrass.mqttclient.v5.SubscribeResponse;
+import com.aws.greengrass.mqttclient.v5.Unsubscribe;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import org.hamcrest.Matchers;
@@ -19,12 +22,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.crt.mqtt.MqttMessage;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -37,7 +41,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class IoTCoreClientTest {
@@ -50,8 +53,20 @@ public class IoTCoreClientTest {
     private final ExecutorService executorService = TestUtils.synchronousExecutorService();
 
     @BeforeEach
-    void beforeEach() {
-        lenient().when(mockIotMqttClient.connected()).thenReturn(true);
+    void beforeEach() throws Exception {
+        resetIotMqttClient();
+    }
+
+    private void resetIotMqttClient() throws Exception {
+        reset(mockIotMqttClient);
+
+        setOnline(true);
+        // TODO fake client
+        lenient().when(mockIotMqttClient.subscribe(any(Subscribe.class)))
+                .thenReturn(CompletableFuture.completedFuture(
+                        new SubscribeResponse("", 0, null)));
+        lenient().when(mockIotMqttClient.unsubscribe(any(Unsubscribe.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
     }
 
     @Test
@@ -68,10 +83,10 @@ public class IoTCoreClientTest {
         iotCoreClient.updateSubscriptions(topics, message -> {
         });
 
-        ArgumentCaptor<SubscribeRequest> requestArgumentCaptor = ArgumentCaptor.forClass(SubscribeRequest.class);
+        ArgumentCaptor<Subscribe> requestArgumentCaptor = ArgumentCaptor.forClass(Subscribe.class);
         verify(mockIotMqttClient, times(2)).subscribe(requestArgumentCaptor.capture());
-        List<SubscribeRequest> argValues = requestArgumentCaptor.getAllValues();
-        assertThat(argValues.stream().map(SubscribeRequest::getTopic).collect(Collectors.toList()),
+        List<Subscribe> argValues = requestArgumentCaptor.getAllValues();
+        assertThat(argValues.stream().map(Subscribe::getTopic).collect(Collectors.toList()),
                 Matchers.containsInAnyOrder("iotcore/topic", "iotcore/topic2"));
 
         assertThat(iotCoreClient.getSubscribedIotCoreTopics(),
@@ -80,7 +95,7 @@ public class IoTCoreClientTest {
 
     @Test
     void GIVEN_offline_iotcore_client_WHEN_update_subscriptions_THEN_subscribe_once_online() throws Exception {
-        reset(mockIotMqttClient);
+        resetIotMqttClient();
 
         IoTCoreClient iotCoreClient = new IoTCoreClient(mockIotMqttClient, executorService);
 
@@ -89,18 +104,18 @@ public class IoTCoreClientTest {
         topics.add("iotcore/topic2");
 
         // attempt to update subscriptions, this is expected to fail since bridge is offline
-        when(mockIotMqttClient.connected()).thenReturn(false);
+        setOnline(false);
         iotCoreClient.updateSubscriptions(topics, message -> {
         });
 
         // verify no subscriptions were made
-        verify(mockIotMqttClient, never()).subscribe(any(SubscribeRequest.class));
+        verify(mockIotMqttClient, never()).subscribe(any(Subscribe.class));
         assertThat(iotCoreClient.getSubscribedIotCoreTopics().size(), is(0));
         assertThat(iotCoreClient.getToSubscribeIotCoreTopics(),
                 Matchers.containsInAnyOrder("iotcore/topic", "iotcore/topic2"));
 
         // simulate mqtt connection resume
-        when(mockIotMqttClient.connected()).thenReturn(true);
+        setOnline(true);
         iotCoreClient.getConnectionCallbacks().onConnectionResumed(false);
 
         // verify subscriptions were made
@@ -110,7 +125,7 @@ public class IoTCoreClientTest {
     }
 
     @Test
-    void GIVEN_iotcore_client_with_subscriptions_WHEN_call_stop_THEN_topics_unsubscribed() throws Exception {
+    void GIVEN_iotcore_client_with_subscriptions_WHEN_call_stop_THEN_topics_Unsubscribed() throws Exception {
         IoTCoreClient iotCoreClient = new IoTCoreClient(mockIotMqttClient, executorService);
         Set<String> topics = new HashSet<>();
         topics.add("iotcore/topic");
@@ -120,10 +135,10 @@ public class IoTCoreClientTest {
 
         iotCoreClient.stop();
 
-        ArgumentCaptor<UnsubscribeRequest> requestArgumentCaptor = ArgumentCaptor.forClass(UnsubscribeRequest.class);
+        ArgumentCaptor<Unsubscribe> requestArgumentCaptor = ArgumentCaptor.forClass(Unsubscribe.class);
         verify(mockIotMqttClient, times(2)).unsubscribe(requestArgumentCaptor.capture());
-        List<UnsubscribeRequest> argValues = requestArgumentCaptor.getAllValues();
-        assertThat(argValues.stream().map(UnsubscribeRequest::getTopic).collect(Collectors.toList()),
+        List<Unsubscribe> argValues = requestArgumentCaptor.getAllValues();
+        assertThat(argValues.stream().map(Unsubscribe::getTopic).collect(Collectors.toList()),
                 Matchers.containsInAnyOrder("iotcore/topic", "iotcore/topic2"));
 
         assertThat(iotCoreClient.getSubscribedIotCoreTopics(), Matchers.hasSize(0));
@@ -139,8 +154,7 @@ public class IoTCoreClientTest {
         iotCoreClient.updateSubscriptions(topics, message -> {
         });
 
-        reset(mockIotMqttClient);
-        lenient().when(mockIotMqttClient.connected()).thenReturn(true);
+        resetIotMqttClient();
 
         topics.clear();
         topics.add("iotcore/topic");
@@ -149,21 +163,21 @@ public class IoTCoreClientTest {
         iotCoreClient.updateSubscriptions(topics, message -> {
         });
 
-        ArgumentCaptor<SubscribeRequest> subRequestArgumentCaptor = ArgumentCaptor.forClass(SubscribeRequest.class);
+        ArgumentCaptor<Subscribe> subRequestArgumentCaptor = ArgumentCaptor.forClass(Subscribe.class);
         verify(mockIotMqttClient, times(2)).subscribe(subRequestArgumentCaptor.capture());
-        List<SubscribeRequest> subArgValues = subRequestArgumentCaptor.getAllValues();
-        assertThat(subArgValues.stream().map(SubscribeRequest::getTopic).collect(Collectors.toList()),
+        List<Subscribe> subArgValues = subRequestArgumentCaptor.getAllValues();
+        assertThat(subArgValues.stream().map(Subscribe::getTopic).collect(Collectors.toList()),
                 Matchers.containsInAnyOrder("iotcore/topic2/changed", "iotcore/topic3/added"));
 
         assertThat(iotCoreClient.getSubscribedIotCoreTopics(), Matchers.hasSize(3));
         assertThat(iotCoreClient.getSubscribedIotCoreTopics(),
                 Matchers.containsInAnyOrder("iotcore/topic", "iotcore/topic2/changed", "iotcore/topic3/added"));
 
-        ArgumentCaptor<UnsubscribeRequest> unsubRequestArgumentCaptor
-                = ArgumentCaptor.forClass(UnsubscribeRequest.class);
+        ArgumentCaptor<Unsubscribe> unsubRequestArgumentCaptor
+                = ArgumentCaptor.forClass(Unsubscribe.class);
         verify(mockIotMqttClient, times(1)).unsubscribe(unsubRequestArgumentCaptor.capture());
-        List<UnsubscribeRequest> unsubArgValues = unsubRequestArgumentCaptor.getAllValues();
-        assertThat(unsubArgValues.stream().map(UnsubscribeRequest::getTopic).collect(Collectors.toList()),
+        List<Unsubscribe> unsubArgValues = unsubRequestArgumentCaptor.getAllValues();
+        assertThat(unsubArgValues.stream().map(Unsubscribe::getTopic).collect(Collectors.toList()),
                 Matchers.containsInAnyOrder("iotcore/topic2"));
     }
 
@@ -176,17 +190,17 @@ public class IoTCoreClientTest {
         topics.add("iotcore/topic2");
         iotCoreClient.updateSubscriptions(topics, mockMessageHandler);
 
-        ArgumentCaptor<SubscribeRequest> requestArgumentCaptor = ArgumentCaptor.forClass(SubscribeRequest.class);
+        ArgumentCaptor<Subscribe> requestArgumentCaptor = ArgumentCaptor.forClass(Subscribe.class);
         verify(mockIotMqttClient, times(2)).subscribe(requestArgumentCaptor.capture());
-        Consumer<MqttMessage> iotCoreCallback = requestArgumentCaptor.getValue().getCallback();
+        Consumer<Publish> iotCoreCallback = requestArgumentCaptor.getValue().getCallback();
 
         byte[] messageOnTopic1 = "message from topic iotcore/topic".getBytes();
         byte[] messageOnTopic2 = "message from topic iotcore/topic2".getBytes();
         byte[] messageOnTopic3 = "message from topic iotcore/topic/not/in/mapping".getBytes();
-        iotCoreCallback.accept(new MqttMessage("iotcore/topic", messageOnTopic1));
-        iotCoreCallback.accept(new MqttMessage("iotcore/topic2", messageOnTopic2));
+        iotCoreCallback.accept(Publish.builder().topic("iotcore/topic").payload(messageOnTopic1).build());
+        iotCoreCallback.accept(Publish.builder().topic("iotcore/topic2").payload(messageOnTopic2).build());
         // Also simulate a message which is not in the mapping
-        iotCoreCallback.accept(new MqttMessage("iotcore/topic/not/in/mapping", messageOnTopic3));
+        iotCoreCallback.accept(Publish.builder().topic("iotcore/topic/not/in/mapping").payload(messageOnTopic3).build());
 
         ArgumentCaptor<com.aws.greengrass.mqtt.bridge.model.MqttMessage> messageCapture = ArgumentCaptor.forClass(com.aws.greengrass.mqtt.bridge.model.MqttMessage.class);
         verify(mockMessageHandler, times(3)).accept(messageCapture.capture());
@@ -199,7 +213,7 @@ public class IoTCoreClientTest {
     }
 
     @Test
-    void GIVEN_iotcore_client_and_subscribed_WHEN_published_message_THEN_routed_to_iotcore_mqttclient() {
+    void GIVEN_iotcore_client_and_subscribed_WHEN_published_message_THEN_routed_to_iotcore_mqttclient() throws MessageClientException, MqttRequestException, SpoolerStoreException, InterruptedException {
         IoTCoreClient iotCoreClient = new IoTCoreClient(mockIotMqttClient, executorService);
         Set<String> topics = new HashSet<>();
         topics.add("iotcore/topic");
@@ -214,7 +228,7 @@ public class IoTCoreClientTest {
                 .payload(messageFromLocalMqtt)
                 .build());
 
-        ArgumentCaptor<PublishRequest> requestCapture = ArgumentCaptor.forClass(PublishRequest.class);
+        ArgumentCaptor<Publish> requestCapture = ArgumentCaptor.forClass(Publish.class);
         verify(mockIotMqttClient, times(1)).publish(requestCapture.capture());
 
         assertThat(requestCapture.getValue().getTopic(), is(Matchers.equalTo("mapped/topic/from/local/mqtt")));
@@ -228,5 +242,9 @@ public class IoTCoreClientTest {
         topics.add("iotcore/topic");
         topics.add("iotcore/topic2");
         assertThrows(NullPointerException.class, () -> iotCoreClient.updateSubscriptions(topics, null));
+    }
+
+    private void setOnline(boolean online) {
+        lenient().when(mockIotMqttClient.getMqttOnline()).thenReturn(new AtomicBoolean(online));
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Use v5 spooler models in `IotCoreClient`.  Async operations not yet supported, will be in a follow-up in https://github.com/aws-greengrass/aws-greengrass-mqtt-bridge/pull/103.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
