### PR TITLE
refactor: add MockMqttClient, cleanup IotCoreClientTest

### DIFF
--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/FakePahoMqtt3Client.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/FakePahoMqtt3Client.java
@@ -21,7 +21,7 @@ import org.eclipse.paho.client.mqttv3.MqttTopic;
 import java.util.ArrayList;
 import java.util.List;
 
-public class FakeMqttClient implements IMqttClient {
+public class FakePahoMqtt3Client implements IMqttClient {
     // To appease PMD
     private static final String UNSUPPORTED_OPERATION = "Unsupported operation";
 
@@ -53,7 +53,7 @@ public class FakeMqttClient implements IMqttClient {
         }
     }
 
-    FakeMqttClient(String clientId) {
+    FakePahoMqtt3Client(String clientId) {
         this.clientId = clientId;
         this.subscriptionTopics = new ArrayList<>();
         this.publishedMessages = new ArrayList<>();

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/FakePahoMqtt3ClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/FakePahoMqtt3ClientTest.java
@@ -20,17 +20,17 @@ import static org.hamcrest.Matchers.is;
 
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class FakeMqttClientTest {
+public class FakePahoMqtt3ClientTest {
     final static String T1 = "my/topic";
     final static String T2 = "my/topic/2";
     final static String T3 = "my/topic/3";
 
-    private FakeMqttClient fakeMQTTClient;
+    private FakePahoMqtt3Client fakeMQTTClient;
 
 
     @BeforeEach
     void setup() {
-        fakeMQTTClient = new FakeMqttClient("clientId");
+        fakeMQTTClient = new FakePahoMqtt3Client("clientId");
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClientTest.java
@@ -5,246 +5,148 @@
 
 package com.aws.greengrass.mqtt.bridge.clients;
 
-import com.aws.greengrass.mqtt.bridge.model.Message;
-import com.aws.greengrass.mqttclient.MqttClient;
-import com.aws.greengrass.mqttclient.MqttRequestException;
-import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
+import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
 import com.aws.greengrass.mqttclient.v5.Publish;
 import com.aws.greengrass.mqttclient.v5.Subscribe;
-import com.aws.greengrass.mqttclient.v5.SubscribeResponse;
-import com.aws.greengrass.mqttclient.v5.Unsubscribe;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class IoTCoreClientTest {
 
-    @Mock
-    private MqttClient mockIotMqttClient;
-
-    @Mock
-    private Consumer<com.aws.greengrass.mqtt.bridge.model.MqttMessage> mockMessageHandler;
-    private final ExecutorService executorService = TestUtils.synchronousExecutorService();
-
-    @BeforeEach
-    void beforeEach() throws Exception {
-        resetIotMqttClient();
-    }
-
-    private void resetIotMqttClient() throws Exception {
-        reset(mockIotMqttClient);
-
-        setOnline(true);
-        // TODO fake client
-        lenient().when(mockIotMqttClient.subscribe(any(Subscribe.class)))
-                .thenReturn(CompletableFuture.completedFuture(
-                        new SubscribeResponse("", 0, null)));
-        lenient().when(mockIotMqttClient.unsubscribe(any(Unsubscribe.class)))
-                .thenReturn(CompletableFuture.completedFuture(null));
-    }
+    MockMqttClient mockMqttClient = new MockMqttClient(false);
+    ExecutorService executorService = TestUtils.synchronousExecutorService();
+    IoTCoreClient iotCoreClient = new IoTCoreClient(mockMqttClient.getMqttClient(), executorService);
 
     @Test
-    void WHEN_call_iotcore_client_constructed_THEN_does_not_throw() {
-        new IoTCoreClient(mockIotMqttClient, executorService);
-    }
-
-    @Test
-    void GIVEN_iotcore_client_started_WHEN_update_subscriptions_THEN_topics_subscribed() throws Exception {
-        IoTCoreClient iotCoreClient = new IoTCoreClient(mockIotMqttClient, executorService);
-        Set<String> topics = new HashSet<>();
-        topics.add("iotcore/topic");
-        topics.add("iotcore/topic2");
-        iotCoreClient.updateSubscriptions(topics, message -> {
-        });
-
-        ArgumentCaptor<Subscribe> requestArgumentCaptor = ArgumentCaptor.forClass(Subscribe.class);
-        verify(mockIotMqttClient, times(2)).subscribe(requestArgumentCaptor.capture());
-        List<Subscribe> argValues = requestArgumentCaptor.getAllValues();
-        assertThat(argValues.stream().map(Subscribe::getTopic).collect(Collectors.toList()),
-                Matchers.containsInAnyOrder("iotcore/topic", "iotcore/topic2"));
-
-        assertThat(iotCoreClient.getSubscribedIotCoreTopics(),
-                Matchers.containsInAnyOrder("iotcore/topic", "iotcore/topic2"));
-    }
-
-    @Test
-    void GIVEN_offline_iotcore_client_WHEN_update_subscriptions_THEN_subscribe_once_online() throws Exception {
-        resetIotMqttClient();
-
-        IoTCoreClient iotCoreClient = new IoTCoreClient(mockIotMqttClient, executorService);
-
+    void GIVEN_client_with_no_subscriptions_WHEN_update_subscriptions_THEN_topics_subscribed() {
         Set<String> topics = new HashSet<>();
         topics.add("iotcore/topic");
         topics.add("iotcore/topic2");
 
-        // attempt to update subscriptions, this is expected to fail since bridge is offline
-        setOnline(false);
-        iotCoreClient.updateSubscriptions(topics, message -> {
-        });
+        iotCoreClient.updateSubscriptions(topics, message -> {});
 
-        // verify no subscriptions were made
-        verify(mockIotMqttClient, never()).subscribe(any(Subscribe.class));
-        assertThat(iotCoreClient.getSubscribedIotCoreTopics().size(), is(0));
-        assertThat(iotCoreClient.getToSubscribeIotCoreTopics(),
-                Matchers.containsInAnyOrder("iotcore/topic", "iotcore/topic2"));
+        assertThat("subscribed topics iot core client", () -> iotCoreClient.getSubscribedIotCoreTopics(), eventuallyEval(is(topics)));
+        assertThat("subscribed topics spooler client", () -> mockMqttClient.getSubscriptions().stream().map(Subscribe::getTopic).collect(Collectors.toSet()), eventuallyEval(is(topics)));
+    }
 
-        // simulate mqtt connection resume
-        setOnline(true);
-        iotCoreClient.getConnectionCallbacks().onConnectionResumed(false);
+    @Test
+    void GIVEN_offline_client_with_no_subscriptions_WHEN_update_subscriptions_THEN_subscribe_once_online() {
+        Set<String> topics = new HashSet<>();
+        topics.add("iotcore/topic");
+        topics.add("iotcore/topic2");
+
+        setOffline();
+        iotCoreClient.updateSubscriptions(topics, message -> {});
+
+        // no topics subscribed
+        assertThat("to subscribe topics", () -> iotCoreClient.getToSubscribeIotCoreTopics(), eventuallyEval(is(topics)));
+        assertTrue(iotCoreClient.getSubscribedIotCoreTopics().isEmpty());
+        assertTrue(mockMqttClient.getSubscriptions().isEmpty());
+
+        setOnline();
 
         // verify subscriptions were made
-        assertThat(iotCoreClient.getSubscribedIotCoreTopics().size(), is(2));
-        assertThat(iotCoreClient.getToSubscribeIotCoreTopics(),
-                Matchers.containsInAnyOrder("iotcore/topic", "iotcore/topic2"));
+        assertThat("subscribed topics iot core client", () -> iotCoreClient.getSubscribedIotCoreTopics(), eventuallyEval(is(topics)));
+        assertThat("subscribed topics spooler client", () -> mockMqttClient.getSubscriptions().stream().map(Subscribe::getTopic).collect(Collectors.toSet()), eventuallyEval(is(topics)));
     }
 
     @Test
-    void GIVEN_iotcore_client_with_subscriptions_WHEN_call_stop_THEN_topics_Unsubscribed() throws Exception {
-        IoTCoreClient iotCoreClient = new IoTCoreClient(mockIotMqttClient, executorService);
+    void GIVEN_client_with_subscriptions_WHEN_stopped_THEN_topics_unsubscribed() {
         Set<String> topics = new HashSet<>();
         topics.add("iotcore/topic");
         topics.add("iotcore/topic2");
-        iotCoreClient.updateSubscriptions(topics, message -> {
-        });
+
+        iotCoreClient.updateSubscriptions(topics, message -> {});
+
+        // verify subscriptions were made
+        assertThat("subscribed topics iot core client", () -> iotCoreClient.getSubscribedIotCoreTopics(), eventuallyEval(is(topics)));
+        assertThat("subscribed topics spooler client", () -> mockMqttClient.getSubscriptions().stream().map(Subscribe::getTopic).collect(Collectors.toSet()), eventuallyEval(is(topics)));
 
         iotCoreClient.stop();
 
-        ArgumentCaptor<Unsubscribe> requestArgumentCaptor = ArgumentCaptor.forClass(Unsubscribe.class);
-        verify(mockIotMqttClient, times(2)).unsubscribe(requestArgumentCaptor.capture());
-        List<Unsubscribe> argValues = requestArgumentCaptor.getAllValues();
-        assertThat(argValues.stream().map(Unsubscribe::getTopic).collect(Collectors.toList()),
-                Matchers.containsInAnyOrder("iotcore/topic", "iotcore/topic2"));
-
-        assertThat(iotCoreClient.getSubscribedIotCoreTopics(), Matchers.hasSize(0));
+        assertThat("iot core client unsubscribed", () -> iotCoreClient.getSubscribedIotCoreTopics().isEmpty(), eventuallyEval(is(true)));
+        assertThat("spooler client unsubscribed", () -> mockMqttClient.getSubscriptions().isEmpty(), eventuallyEval(is(true)));
     }
 
     @Test
-    void GIVEN_iotcore_client_with_subscriptions_WHEN_subscriptions_updated_THEN_subscriptions_updated()
-            throws Exception {
-        IoTCoreClient iotCoreClient = new IoTCoreClient(mockIotMqttClient, executorService);
+    void GIVEN_client_with_subscriptions_WHEN_new_topic_added_THEN_subscription_made() {
         Set<String> topics = new HashSet<>();
         topics.add("iotcore/topic");
         topics.add("iotcore/topic2");
-        iotCoreClient.updateSubscriptions(topics, message -> {
-        });
 
-        resetIotMqttClient();
+        iotCoreClient.updateSubscriptions(topics, message -> {});
 
-        topics.clear();
+        // verify subscriptions were made
+        assertThat("subscribed topics iot core client", () -> iotCoreClient.getSubscribedIotCoreTopics(), eventuallyEval(is(topics)));
+        assertThat("subscribed topics spooler client", () -> mockMqttClient.getSubscriptions().stream().map(Subscribe::getTopic).collect(Collectors.toSet()), eventuallyEval(is(topics)));
+
+        topics = new HashSet<>();
         topics.add("iotcore/topic");
         topics.add("iotcore/topic2/changed");
         topics.add("iotcore/topic3/added");
-        iotCoreClient.updateSubscriptions(topics, message -> {
-        });
 
-        ArgumentCaptor<Subscribe> subRequestArgumentCaptor = ArgumentCaptor.forClass(Subscribe.class);
-        verify(mockIotMqttClient, times(2)).subscribe(subRequestArgumentCaptor.capture());
-        List<Subscribe> subArgValues = subRequestArgumentCaptor.getAllValues();
-        assertThat(subArgValues.stream().map(Subscribe::getTopic).collect(Collectors.toList()),
-                Matchers.containsInAnyOrder("iotcore/topic2/changed", "iotcore/topic3/added"));
+        iotCoreClient.updateSubscriptions(topics, message -> {});
 
-        assertThat(iotCoreClient.getSubscribedIotCoreTopics(), Matchers.hasSize(3));
-        assertThat(iotCoreClient.getSubscribedIotCoreTopics(),
-                Matchers.containsInAnyOrder("iotcore/topic", "iotcore/topic2/changed", "iotcore/topic3/added"));
-
-        ArgumentCaptor<Unsubscribe> unsubRequestArgumentCaptor
-                = ArgumentCaptor.forClass(Unsubscribe.class);
-        verify(mockIotMqttClient, times(1)).unsubscribe(unsubRequestArgumentCaptor.capture());
-        List<Unsubscribe> unsubArgValues = unsubRequestArgumentCaptor.getAllValues();
-        assertThat(unsubArgValues.stream().map(Unsubscribe::getTopic).collect(Collectors.toList()),
-                Matchers.containsInAnyOrder("iotcore/topic2"));
+        // verify subscriptions were made
+        assertThat("subscribed topics iot core client", () -> iotCoreClient.getSubscribedIotCoreTopics(), eventuallyEval(is(topics)));
+        assertThat("subscribed topics spooler client", () -> mockMqttClient.getSubscriptions().stream().map(Subscribe::getTopic).collect(Collectors.toSet()), eventuallyEval(is(topics)));
     }
 
     @Test
-    void GIVEN_iotcore_client_and_subscribed_WHEN_receive_iotcore_message_THEN_routed_to_message_handler()
-            throws Exception {
-        IoTCoreClient iotCoreClient = new IoTCoreClient(mockIotMqttClient, executorService);
+    void GIVEN_client_with_subscriptions_WHEN_message_published_THEN_message_handler_invoked() throws Exception {
         Set<String> topics = new HashSet<>();
         topics.add("iotcore/topic");
         topics.add("iotcore/topic2");
-        iotCoreClient.updateSubscriptions(topics, mockMessageHandler);
 
-        ArgumentCaptor<Subscribe> requestArgumentCaptor = ArgumentCaptor.forClass(Subscribe.class);
-        verify(mockIotMqttClient, times(2)).subscribe(requestArgumentCaptor.capture());
-        Consumer<Publish> iotCoreCallback = requestArgumentCaptor.getValue().getCallback();
+        Set<String> topicsReceived = ConcurrentHashMap.newKeySet();
+        iotCoreClient.updateSubscriptions(topics, m -> topicsReceived.add(m.getTopic()));
 
-        byte[] messageOnTopic1 = "message from topic iotcore/topic".getBytes();
-        byte[] messageOnTopic2 = "message from topic iotcore/topic2".getBytes();
-        byte[] messageOnTopic3 = "message from topic iotcore/topic/not/in/mapping".getBytes();
-        iotCoreCallback.accept(Publish.builder().topic("iotcore/topic").payload(messageOnTopic1).build());
-        iotCoreCallback.accept(Publish.builder().topic("iotcore/topic2").payload(messageOnTopic2).build());
-        // Also simulate a message which is not in the mapping
-        iotCoreCallback.accept(Publish.builder().topic("iotcore/topic/not/in/mapping").payload(messageOnTopic3).build());
+        // verify subscriptions were made
+        assertThat("subscribed topics iot core client", () -> iotCoreClient.getSubscribedIotCoreTopics(), eventuallyEval(is(topics)));
+        assertThat("subscribed topics spooler client", () -> mockMqttClient.getSubscriptions().stream().map(Subscribe::getTopic).collect(Collectors.toSet()), eventuallyEval(is(topics)));
 
-        ArgumentCaptor<com.aws.greengrass.mqtt.bridge.model.MqttMessage> messageCapture = ArgumentCaptor.forClass(com.aws.greengrass.mqtt.bridge.model.MqttMessage.class);
-        verify(mockMessageHandler, times(3)).accept(messageCapture.capture());
+        iotCoreClient.publish(MqttMessage.builder().topic("iotcore/topic").payload("message1".getBytes()).build());
+        iotCoreClient.publish(MqttMessage.builder().topic("iotcore/topic2").payload("message2".getBytes()).build());
+        iotCoreClient.publish(MqttMessage.builder().topic("iotcore/topic/not/in/mapping").payload("message3".getBytes()).build());
 
-        List<com.aws.greengrass.mqtt.bridge.model.MqttMessage> argValues = messageCapture.getAllValues();
-        assertThat(argValues.stream().map(Message::getTopic).collect(Collectors.toList()),
-                Matchers.containsInAnyOrder("iotcore/topic", "iotcore/topic2", "iotcore/topic/not/in/mapping"));
-        assertThat(argValues.stream().map(Message::getPayload).collect(Collectors.toList()),
-                Matchers.containsInAnyOrder(messageOnTopic1, messageOnTopic2, messageOnTopic3));
-    }
+        Set<String> topicsPublished = new HashSet<>(topics);
+        topicsPublished.add("iotcore/topic/not/in/mapping");
+        assertThat("messages published", () -> mockMqttClient.getPublished().stream().map(Publish::getTopic).collect(Collectors.toSet()), eventuallyEval(is(topicsPublished)));
 
-    @Test
-    void GIVEN_iotcore_client_and_subscribed_WHEN_published_message_THEN_routed_to_iotcore_mqttclient() throws MessageClientException, MqttRequestException, SpoolerStoreException, InterruptedException {
-        IoTCoreClient iotCoreClient = new IoTCoreClient(mockIotMqttClient, executorService);
-        Set<String> topics = new HashSet<>();
-        topics.add("iotcore/topic");
-        topics.add("iotcore/topic2");
-        iotCoreClient.updateSubscriptions(topics, message -> {
-        });
-
-        byte[] messageFromLocalMqtt = "message from local mqtt".getBytes();
-
-        iotCoreClient.publish(com.aws.greengrass.mqtt.bridge.model.MqttMessage.builder()
-                .topic("mapped/topic/from/local/mqtt")
-                .payload(messageFromLocalMqtt)
-                .build());
-
-        ArgumentCaptor<Publish> requestCapture = ArgumentCaptor.forClass(Publish.class);
-        verify(mockIotMqttClient, times(1)).publish(requestCapture.capture());
-
-        assertThat(requestCapture.getValue().getTopic(), is(Matchers.equalTo("mapped/topic/from/local/mqtt")));
-        assertThat(requestCapture.getValue().getPayload(), is(Matchers.equalTo(messageFromLocalMqtt)));
+        assertThat("handlers invoked", () -> topicsReceived, eventuallyEval(is(topics)));
     }
 
     @Test
     void GIVEN_iotcore_client_WHEN_update_subscriptions_with_null_message_handler_THEN_throws() {
-        IoTCoreClient iotCoreClient = new IoTCoreClient(mockIotMqttClient, executorService);
         Set<String> topics = new HashSet<>();
         topics.add("iotcore/topic");
         topics.add("iotcore/topic2");
         assertThrows(NullPointerException.class, () -> iotCoreClient.updateSubscriptions(topics, null));
     }
 
-    private void setOnline(boolean online) {
-        lenient().when(mockIotMqttClient.getMqttOnline()).thenReturn(new AtomicBoolean(online));
+    private void setOnline() {
+        mockMqttClient.online();
+        iotCoreClient.getConnectionCallbacks().onConnectionResumed(mockMqttClient.isCleanSession());
+    }
+
+    private void setOffline() {
+        mockMqttClient.offline();
+        iotCoreClient.getConnectionCallbacks().onConnectionInterrupted(0);
     }
 }

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClientTest.java
@@ -41,7 +41,7 @@ public class MQTTClientTest {
     private static final URI ENCRYPTED_URI = URI.create("ssl://localhost:8883");
     private static final String CLIENT_ID = "mqtt-bridge-1234";
 
-    private FakeMqttClient fakeMqttClient;
+    private FakePahoMqtt3Client fakeMqttClient;
 
     @Mock
     private MQTTClientKeyStore mockMqttClientKeyStore;
@@ -50,7 +50,7 @@ public class MQTTClientTest {
 
     @BeforeEach
     void setup() {
-        fakeMqttClient = new FakeMqttClient(CLIENT_ID);
+        fakeMqttClient = new FakePahoMqtt3Client(CLIENT_ID);
     }
 
     @AfterEach
@@ -179,7 +179,7 @@ public class MQTTClientTest {
         mqttClient.publish(com.aws.greengrass.mqtt.bridge.model.MqttMessage.builder().topic("from/pubsub").payload(messageFromPubsub).build());
         mqttClient.publish(com.aws.greengrass.mqtt.bridge.model.MqttMessage.builder().topic("from/iotcore").payload(messageFromIotCore).build());
 
-        List<FakeMqttClient.TopicMessagePair> publishedMessages = fakeMqttClient.getPublishedMessages();
+        List<FakePahoMqtt3Client.TopicMessagePair> publishedMessages = fakeMqttClient.getPublishedMessages();
         assertThat(publishedMessages.size(), is(2));
         assertThat(publishedMessages.get(0).getTopic(), equalTo("from/pubsub"));
         assertThat(publishedMessages.get(0).getMessage().getPayload(), equalTo(messageFromPubsub));

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/MockMqttClient.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/MockMqttClient.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqtt.bridge.clients;
+
+import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.mqttclient.MqttRequestException;
+import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
+import com.aws.greengrass.mqttclient.v5.Publish;
+import com.aws.greengrass.mqttclient.v5.PublishResponse;
+import com.aws.greengrass.mqttclient.v5.Subscribe;
+import com.aws.greengrass.mqttclient.v5.SubscribeResponse;
+import com.aws.greengrass.mqttclient.v5.Unsubscribe;
+import lombok.Getter;
+import org.mockito.invocation.InvocationOnMock;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+public class MockMqttClient {
+
+    private final AtomicBoolean online = new AtomicBoolean(true);
+    private final Object subscriptionsLock = new Object();
+    @Getter
+    private final List<Subscribe> subscriptions = new ArrayList<>();
+    private final Object publishLock = new Object();
+    @Getter
+    private final List<Publish> toPublish = new ArrayList<>();
+    @Getter
+    private final List<Publish> published = new ArrayList<>();
+
+    @Getter
+    private final boolean cleanSession;
+
+    @Getter
+    private final MqttClient mqttClient;
+
+    public MockMqttClient(boolean cleanSession){
+        this.cleanSession = cleanSession;
+        this.mqttClient = mock(MqttClient.class);
+
+        lenient().when(mqttClient.getMqttOnline()).thenReturn(online);
+        try {
+            lenient().doAnswer(this::onSubscribe).when(mqttClient).subscribe(any(Subscribe.class));
+            lenient().doAnswer(this::onPublish).when(mqttClient).publish(any(Publish.class));
+            lenient().doAnswer(this::onUnsubscribe).when(mqttClient).unsubscribe(any(Unsubscribe.class));
+        } catch (MqttRequestException | SpoolerStoreException | InterruptedException e) {
+            fail(e);
+        }
+    }
+
+    private CompletableFuture<SubscribeResponse> onSubscribe(InvocationOnMock invocation) {
+        if (!online.get()) {
+            CompletableFuture<SubscribeResponse> resp = new CompletableFuture<>();
+            resp.completeExceptionally(new RuntimeException("subscription failed, not connected"));
+            return resp;
+        }
+        Subscribe subscribe = invocation.getArgument(0);
+        synchronized (subscriptionsLock) {
+            subscriptions.add(subscribe);
+        }
+        return CompletableFuture.completedFuture(
+                new SubscribeResponse("", 0, null));
+    }
+
+    private PublishResponse onPublish(InvocationOnMock invocation) {
+        Publish publish = invocation.getArgument(0);
+        toPublish.add(publish);
+        flush();
+        return new PublishResponse();
+    }
+
+    private CompletableFuture<Void> onUnsubscribe(InvocationOnMock invocation) {
+        if (!online.get()) {
+            CompletableFuture<Void> resp = new CompletableFuture<>();
+            resp.completeExceptionally(new RuntimeException("unsubscribe failed, not connected"));
+            return resp;
+        }
+        Unsubscribe unsubscribe = invocation.getArgument(0);
+        synchronized (subscriptionsLock) {
+            subscriptions.removeIf(s -> s.getTopic().equals(unsubscribe.getTopic()));
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private void flush() {
+        synchronized (publishLock) {
+            Iterator<Publish> iter = toPublish.iterator();
+            while (iter.hasNext()) {
+                if (!online.get()) {
+                    return;
+                }
+                Publish publish = iter.next();
+                published.add(publish);
+                synchronized (subscriptionsLock) {
+                    for (Subscribe subscribe : subscriptions) {
+                        if (subscribe.getTopic().equals(publish.getTopic())) {
+                            subscribe.getCallback().accept(publish);
+                        }
+                    }
+                }
+                iter.remove();
+            }
+        }
+    }
+
+    public void online() {
+        online.set(true);
+        onConnect();
+        flush();
+    }
+
+    public void offline() {
+        online.set(false);
+    }
+
+    private void onConnect() {
+        if (cleanSession) {
+            synchronized (subscriptionsLock) {
+                subscriptions.clear();
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

* New `MockMqttClient`, which tries to be a fake, although it accomplishes it using mocks since MqttClient doesn't have an interface
* Rename `FakeMqttClient[Test]` to `FakePahoMqtt3Client[Test]` for clarity, since we now have CRT and mqtt5 in the mix.
* Utilize `MockMqttClient` in `IotCoreClientTest`

**Why is this change necessary:**

* allows `IotCoreClientTest` to work regardless if `IotCoreClient` impl is sync or async
* `MockMqttClient` can be used in integration tests

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
