### PR TITLE
chore: utilize IotCoreClient in integration tests

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/BridgeTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/BridgeTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests;
+
+import com.aws.greengrass.integrationtests.extensions.BridgeIntegrationTest;
+import com.aws.greengrass.integrationtests.extensions.BridgeIntegrationTestContext;
+import com.aws.greengrass.integrationtests.extensions.Broker;
+import com.aws.greengrass.integrationtests.extensions.TestWithAllBrokers;
+import com.aws.greengrass.integrationtests.extensions.WithKernel;
+import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
+import com.aws.greengrass.mqttclient.v5.Publish;
+import com.aws.greengrass.mqttclient.v5.Subscribe;
+import com.aws.greengrass.mqttclient.v5.UserProperty;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@BridgeIntegrationTest
+public class BridgeTest {
+
+    BridgeIntegrationTestContext context;
+
+    @TestWithAllBrokers
+    @WithKernel("mqtt3_local_and_iotcore.yaml")
+    void GIVEN_mqtt3_and_mapping_between_local_and_iotcore_WHEN_iotcore_message_received_THEN_message_bridged_to_local(Broker broker) throws Exception {
+        CountDownLatch messageReceived = new CountDownLatch(1);
+        AtomicReference<MqttMessage> m = new AtomicReference<>();
+        context.getLocalV3Client().getMqttClientInternal().subscribe("topic/toLocal", (topic, message) -> {
+            messageReceived.countDown();
+            m.compareAndSet(null, MqttMessage.fromPahoMQTT3(topic, message));
+        });
+
+        context.getIotCoreClient().publish(
+                MqttMessage.builder()
+                        .topic("topic/toLocal")
+                        .payload("message".getBytes(StandardCharsets.UTF_8))
+                        // mqtt5-specific fields below.
+                        // this test uses mqtt3 protocol,
+                        // so we expect this fields to be dropped during bridging
+                        .userProperties(Collections.singletonList(new UserProperty("key", "val")))
+                        .responseTopic("response topic")
+                        .messageExpiryIntervalSeconds(1234L)
+                        .payloadFormat(Publish.PayloadFormatIndicator.UTF8)
+                        .contentType("contentType")
+                        .build());
+
+        assertTrue(messageReceived.await(10L, TimeUnit.SECONDS));
+
+        MqttMessage expectedMessage = MqttMessage.builder()
+                .topic("topic/toLocal")
+                .payload("message".getBytes(StandardCharsets.UTF_8))
+                .build();
+
+        assertEquals(expectedMessage, m.get());
+    }
+
+    @TestWithAllBrokers
+    @WithKernel("mqtt3_local_and_iotcore.yaml")
+    void GIVEN_mqtt3_and_mapping_between_local_and_iotcore_WHEN_local_message_received_THEN_message_bridged_to_iotcore(Broker broker) throws Exception {
+        CountDownLatch messageReceived = new CountDownLatch(1);
+        AtomicReference<MqttMessage> m = new AtomicReference<>();
+        context.getIotCoreClient().getIotMqttClient().subscribe(Subscribe.builder()
+                .topic("topic/toIotCore")
+                .callback(p -> {
+                    messageReceived.countDown();
+                    m.compareAndSet(null, MqttMessage.fromSpoolerV5Model(p));
+                })
+                .build());
+
+        context.getLocalV3Client().publish(
+                MqttMessage.builder()
+                        .topic("topic/toIotCore")
+                        .payload("message".getBytes(StandardCharsets.UTF_8))
+                        // mqtt5-specific fields below.
+                        // will be ignored by v3 mqtt client
+                        .userProperties(Collections.singletonList(new UserProperty("key", "val")))
+                        .responseTopic("response topic")
+                        .messageExpiryIntervalSeconds(1234L)
+                        .payloadFormat(Publish.PayloadFormatIndicator.UTF8)
+                        .contentType("contentType")
+                        .build());
+
+        assertTrue(messageReceived.await(10L, TimeUnit.SECONDS));
+
+        MqttMessage expectedMessage = MqttMessage.builder()
+                .topic("topic/toIotCore")
+                .payload("message".getBytes(StandardCharsets.UTF_8))
+                .build();
+
+        assertEquals(expectedMessage, m.get());
+    }
+}

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestContext.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestContext.java
@@ -6,6 +6,13 @@
 package com.aws.greengrass.integrationtests.extensions;
 
 import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.mqtt.bridge.BridgeConfig;
+import com.aws.greengrass.mqtt.bridge.MQTTBridge;
+import com.aws.greengrass.mqtt.bridge.clients.IoTCoreClient;
+import com.aws.greengrass.mqtt.bridge.clients.MQTTClient;
+import com.aws.greengrass.mqtt.bridge.clients.MessageClient;
+import com.aws.greengrass.mqtt.bridge.clients.MockMqttClient;
+import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
 import lombok.Data;
 
 import java.nio.file.Path;
@@ -17,4 +24,32 @@ public class BridgeIntegrationTestContext {
     String brokerHost;
     Path rootDir;
     Kernel kernel;
+
+    public MockMqttClient getMockMqttClient() {
+        return getFromContext(MockMqttClient.class);
+    }
+
+    public IoTCoreClient getIotCoreClient() {
+        return getFromContext(IoTCoreClient.class);
+    }
+
+    public MQTTClient getLocalV3Client() {
+        MessageClient<MqttMessage> client = getFromContext(MQTTBridge.class).getLocalMqttClient();
+        if (!(client instanceof MQTTClient)) {
+            throw new RuntimeException("Excepted " + MQTTClient.class.getSimpleName()
+                    + " but got " + client.getClass().getSimpleName());
+        }
+        return (MQTTClient) client;
+    }
+
+    public BridgeConfig getConfig() {
+        return getFromContext(MQTTBridge.class).getBridgeConfig();
+    }
+
+    public <T> T getFromContext(Class<T> clazz) {
+        if (kernel == null) {
+            throw new RuntimeException("Kernel not available. Ensure the test method is annotated with @WithKernel");
+        }
+        return kernel.getContext().get(clazz);
+    }
 }

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt3_local_and_iotcore.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt3_local_and_iotcore.yaml
@@ -1,0 +1,16 @@
+services:
+  aws.greengrass.clientdevices.mqtt.Bridge:
+    configuration:
+      brokerUri: 'tcp://localhost:8883'
+      mqttTopicMapping:
+        toIotCore:
+          topic: topic/toIotCore
+          source: LocalMqtt
+          target: IotCore
+        toLocal:
+          topic: topic/toLocal
+          source: IotCore
+          target: LocalMqtt
+  main:
+    dependencies:
+      - aws.greengrass.clientdevices.mqtt.Bridge

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -51,6 +51,7 @@ public class MQTTBridge extends PluginService {
     private final LocalMqttClientFactory localMqttClientFactory;
     private final ConfigurationChangeHandler configurationChangeHandler;
     private final CertificateAuthorityChangeHandler certificateAuthorityChangeHandler;
+    @Getter // for tests
     private MessageClient<MqttMessage> localMqttClient;
     private PubSubClient pubSubClient;
     private IoTCoreClient ioTCoreClient;

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/IoTCoreClient.java
@@ -48,6 +48,7 @@ public class IoTCoreClient implements MessageClient<com.aws.greengrass.mqtt.brid
     private volatile Consumer<com.aws.greengrass.mqtt.bridge.model.MqttMessage> messageHandler;
     private Future<?> subscribeFuture;
     private final Object subscribeLock = new Object();
+    @Getter // for testing
     private final MqttClient iotMqttClient;
     private final ExecutorService executorService;
 

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
@@ -53,6 +53,7 @@ public class MQTTClient implements MessageClient<MqttMessage> {
     private final Object subscribeLock = new Object();
     private Future<?> connectFuture;
     private Future<?> subscribeFuture;
+    @Getter // for testing
     private IMqttClient mqttClientInternal;
     @Getter(AccessLevel.PROTECTED)
     private Set<String> subscribedLocalMqttTopics = ConcurrentHashMap.newKeySet();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Adds a new integration test, `BridgeTest` for exercising message bridging between message clients.  For now a few tests for bridging IotCore <--> Local (v3) were added, making use of the mock mqttclient from https://github.com/aws-greengrass/aws-greengrass-mqtt-bridge/pull/105.

Also improves integration test extension so that it waits for local mqtt client to fully connect before executing the test. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
