### PR TITLE
chore: handle missing broker port in config

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -103,11 +103,17 @@ public final class BridgeConfig {
                 configurationTopics.findOrDefault(DEFAULT_BROKER_URI, KEY_BROKER_SERVER_URI));
         String brokerUri = Coerce.toString(
                 configurationTopics.findOrDefault(brokerServerUri, KEY_BROKER_URI));
+        URI uri;
         try {
-            return new URI(brokerUri);
+            uri = new URI(brokerUri);
         } catch (URISyntaxException e) {
             throw new InvalidConfigurationException("Malformed " + KEY_BROKER_URI + ": " + brokerUri, e);
         }
+
+        if (uri.getPort() < 0) {
+            throw new InvalidConfigurationException("Port missing in  " + KEY_BROKER_URI + ": " + brokerUri);
+        }
+        return uri;
     }
 
     private static String getClientId(Topics configurationTopics) {

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -123,6 +123,12 @@ class BridgeConfigTest {
     }
 
     @Test
+    void GIVEN_brokerUri_with_missing_port_WHEN_bridge_config_created_THEN_exception_thrown() {
+        topics.lookup(BridgeConfig.KEY_BROKER_URI).dflt("tcp://localhost");
+        assertThrows(InvalidConfigurationException.class, () -> BridgeConfig.fromTopics(topics));
+    }
+
+    @Test
     void GIVEN_clientId_config_WHEN_bridge_config_created_THEN_clientId_used() throws InvalidConfigurationException {
         topics.lookup(BridgeConfig.KEY_CLIENT_ID).dflt(CLIENT_ID);
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

If no port is provided in brokerUri, default to 1883 or 8883, based on the brokerUri protocol being tcp or ssl

**Why is this change necessary:**

For upcoming LocalMqtt5Client which uses URI.getPort()

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
