### PR TITLE
refactor: injectable bridge config

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.mqtt.bridge.BridgeConfig;
 import com.aws.greengrass.mqtt.bridge.MQTTBridge;
 import com.aws.greengrass.mqtt.bridge.TopicMapping;
+import com.aws.greengrass.mqtt.bridge.model.BridgeConfigReference;
 import com.aws.greengrass.mqtt.bridge.model.Mqtt5RouteOptions;
 import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
@@ -181,7 +182,7 @@ public class ConfigTest {
         expectedRouteOptions.put("mappingNotInMqttTopicMapping", Mqtt5RouteOptions.builder().noLocal(true).retainAsPublished(true).build());
 
         Map<String, Mqtt5RouteOptions> actualRouteOptions =
-                testContext.getKernel().getContext().get(MQTTBridge.class).getBridgeConfig().getMqtt5RouteOptions();
+                testContext.getKernel().getContext().get(BridgeConfigReference.class).get().getMqtt5RouteOptions();
 
         assertEquals(expectedRouteOptions, actualRouteOptions);
     }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestContext.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestContext.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.mqtt.bridge.clients.LocalMqtt5Client;
 import com.aws.greengrass.mqtt.bridge.clients.MQTTClient;
 import com.aws.greengrass.mqtt.bridge.clients.MessageClient;
 import com.aws.greengrass.mqtt.bridge.clients.MockMqttClient;
+import com.aws.greengrass.mqtt.bridge.model.BridgeConfigReference;
 import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
 import lombok.Data;
 
@@ -53,7 +54,7 @@ public class BridgeIntegrationTestContext {
     }
 
     public BridgeConfig getConfig() {
-        return getFromContext(MQTTBridge.class).getBridgeConfig();
+        return getFromContext(BridgeConfigReference.class).get();
     }
 
     public <T> T getFromContext(Class<T> clazz) {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -22,6 +22,7 @@ import com.aws.greengrass.mqtt.bridge.clients.LocalMqttClientFactory;
 import com.aws.greengrass.mqtt.bridge.clients.MessageClient;
 import com.aws.greengrass.mqtt.bridge.clients.MessageClientException;
 import com.aws.greengrass.mqtt.bridge.clients.PubSubClient;
+import com.aws.greengrass.mqtt.bridge.model.BridgeConfigReference;
 import com.aws.greengrass.mqtt.bridge.model.InvalidConfigurationException;
 import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
 import com.aws.greengrass.mqttclient.MqttClient;
@@ -55,8 +56,8 @@ public class MQTTBridge extends PluginService {
     private MessageClient<MqttMessage> localMqttClient;
     private PubSubClient pubSubClient;
     private IoTCoreClient ioTCoreClient;
-    @Getter // for unit testing
-    private BridgeConfig bridgeConfig;
+    @Getter // for tests
+    private final BridgeConfigReference bridgeConfig;
 
 
     /**
@@ -70,21 +71,25 @@ public class MQTTBridge extends PluginService {
      * @param mqttClientKeyStore     KeyStore for MQTT Client
      * @param localMqttClientFactory local mqtt client factory
      * @param executorService        Executor service
+     * @param bridgeConfig           reference to bridge config
      */
     @Inject
     public MQTTBridge(Topics topics, TopicMapping topicMapping, PubSubIPCEventStreamAgent pubSubIPCAgent,
                       MqttClient iotMqttClient, Kernel kernel, MQTTClientKeyStore mqttClientKeyStore,
                       LocalMqttClientFactory localMqttClientFactory,
-                      ExecutorService executorService) {
+                      ExecutorService executorService,
+                      BridgeConfigReference bridgeConfig) {
         this(topics, topicMapping, new MessageBridge(topicMapping), pubSubIPCAgent, iotMqttClient,
-                kernel, mqttClientKeyStore, localMqttClientFactory, executorService);
+                kernel, mqttClientKeyStore, localMqttClientFactory, executorService, bridgeConfig);
     }
 
+    @SuppressWarnings("PMD.ExcessiveParameterList")
     protected MQTTBridge(Topics topics, TopicMapping topicMapping, MessageBridge messageBridge,
                          PubSubIPCEventStreamAgent pubSubIPCAgent, MqttClient iotMqttClient, Kernel kernel,
                          MQTTClientKeyStore mqttClientKeyStore,
                          LocalMqttClientFactory localMqttClientFactory,
-                         ExecutorService executorService) {
+                         ExecutorService executorService,
+                         BridgeConfigReference bridgeConfig) {
         super(topics);
         this.topicMapping = topicMapping;
         this.kernel = kernel;
@@ -95,6 +100,7 @@ public class MQTTBridge extends PluginService {
         this.localMqttClientFactory = localMqttClientFactory;
         this.configurationChangeHandler = new ConfigurationChangeHandler();
         this.certificateAuthorityChangeHandler = new CertificateAuthorityChangeHandler();
+        this.bridgeConfig = bridgeConfig;
     }
 
     @Override
@@ -243,22 +249,22 @@ public class MQTTBridge extends PluginService {
         private final Topics configurationTopics = config.lookupTopics(KernelConfigResolver.CONFIGURATION_CONFIG_KEY);
 
         private final BatchedSubscriber subscriber = new BatchedSubscriber(configurationTopics, (what) -> {
-            BridgeConfig prevConfig = bridgeConfig;
+            BridgeConfig newConfig;
             try {
-                bridgeConfig = BridgeConfig.fromTopics(configurationTopics);
+                newConfig = BridgeConfig.fromTopics(configurationTopics);
             } catch (InvalidConfigurationException e) {
                 serviceErrored(e);
                 return;
             }
 
-            localMqttClientFactory.setConfig(bridgeConfig);
+            BridgeConfig prevConfig = bridgeConfig.getAndUpdate(c -> newConfig);
 
             // update topic mapping
-            if (prevConfig == null || !Objects.equals(prevConfig.getTopicMapping(), bridgeConfig.getTopicMapping())) {
+            if (prevConfig == null || !Objects.equals(prevConfig.getTopicMapping(), newConfig.getTopicMapping())) {
                 logger.atInfo("service-config-change")
-                        .kv("mapping", bridgeConfig.getTopicMapping())
+                        .kv("mapping", newConfig.getTopicMapping())
                         .log("Updating mapping");
-                topicMapping.updateMapping(bridgeConfig.getTopicMapping());
+                topicMapping.updateMapping(newConfig.getTopicMapping());
             }
 
             // initial config
@@ -266,7 +272,7 @@ public class MQTTBridge extends PluginService {
                 return;
             }
 
-            if (bridgeConfig.reinstallRequired(prevConfig)) {
+            if (newConfig.reinstallRequired(prevConfig)) {
                 logger.atInfo("service-config-change")
                         .log("Requesting re-installation of bridge");
                 requestReinstall();

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -257,7 +257,7 @@ public class MQTTBridge extends PluginService {
                 return;
             }
 
-            BridgeConfig prevConfig = bridgeConfig.getAndUpdate(c -> newConfig);
+            BridgeConfig prevConfig = bridgeConfig.getAndSet(newConfig);
 
             // update topic mapping
             if (prevConfig == null || !Objects.equals(prevConfig.getTopicMapping(), newConfig.getTopicMapping())) {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
@@ -45,7 +45,7 @@ public class LocalMqttClientFactory {
     public MessageClient<MqttMessage> createLocalMqttClient() throws MessageClientException {
         BridgeConfig config = this.config.get();
         if (config == null) {
-            throw new IllegalStateException("Bridge configuration not set");
+            throw new MessageClientException("Unable to create message client, bridge configuration not set");
         }
         switch (config.getMqttVersion()) {
             case MQTT5:

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
@@ -8,23 +8,30 @@ package com.aws.greengrass.mqtt.bridge.clients;
 
 import com.aws.greengrass.mqtt.bridge.BridgeConfig;
 import com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore;
+import com.aws.greengrass.mqtt.bridge.model.BridgeConfigReference;
 import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
-import lombok.Setter;
 
 import java.util.concurrent.ExecutorService;
 import javax.inject.Inject;
 
 public class LocalMqttClientFactory {
 
+    private final BridgeConfigReference config;
     private final MQTTClientKeyStore mqttClientKeyStore;
     private final ExecutorService executorService;
 
-    @Setter
-    private BridgeConfig config;
-
+    /**
+     * Create a new LocalMqttClientFactory.
+     *
+     * @param config             bridge config
+     * @param mqttClientKeyStore mqtt client key store
+     * @param executorService    executor service
+     */
     @Inject
-    public LocalMqttClientFactory(MQTTClientKeyStore mqttClientKeyStore,
+    public LocalMqttClientFactory(BridgeConfigReference config,
+                                  MQTTClientKeyStore mqttClientKeyStore,
                                   ExecutorService executorService) {
+        this.config = config;
         this.mqttClientKeyStore = mqttClientKeyStore;
         this.executorService = executorService;
     }
@@ -36,21 +43,22 @@ public class LocalMqttClientFactory {
      * @throws MessageClientException if unable to create client
      */
     public MessageClient<MqttMessage> createLocalMqttClient() throws MessageClientException {
-        checkConfig();
+        BridgeConfig config = this.config.get();
+        if (config == null) {
+            throw new IllegalStateException("Bridge configuration not set");
+        }
         switch (config.getMqttVersion()) {
             case MQTT5:
-                return new LocalMqtt5Client(config.getBrokerUri(), config.getClientId(),
-                        mqttClientKeyStore, executorService);
+                return new LocalMqtt5Client(
+                        config.getBrokerUri(),
+                        config.getClientId(),
+                        mqttClientKeyStore,
+                        executorService
+                );
             case MQTT3: // fall-through
             default:
                 return new MQTTClient(config.getBrokerUri(), config.getClientId(),
                         mqttClientKeyStore, executorService);
-        }
-    }
-
-    private void checkConfig() {
-        if (config == null) {
-            throw new IllegalStateException("config is missing, ensure setConfig() is called");
         }
     }
 }

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/model/BridgeConfigReference.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/model/BridgeConfigReference.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqtt.bridge.model;
+
+import com.aws.greengrass.mqtt.bridge.BridgeConfig;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Convenience wrapper for BridgeConfig to make it injectable in other classes.
+ * Value of this reference is managed by {@link com.aws.greengrass.mqtt.bridge.MQTTBridge}.
+ */
+public class BridgeConfigReference extends AtomicReference<BridgeConfig> {
+    private static final long serialVersionUID = 4845695073418707546L;
+}

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
@@ -16,6 +16,7 @@ import com.aws.greengrass.mqtt.bridge.clients.IoTCoreClient;
 import com.aws.greengrass.mqtt.bridge.clients.LocalMqttClientFactory;
 import com.aws.greengrass.mqtt.bridge.clients.MessageClient;
 import com.aws.greengrass.mqtt.bridge.clients.PubSubClient;
+import com.aws.greengrass.mqtt.bridge.model.BridgeConfigReference;
 import com.aws.greengrass.mqtt.bridge.model.Message;
 import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
 import com.aws.greengrass.mqttclient.MqttClient;
@@ -81,7 +82,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
             try (MqttClient mockIotMqttClient = mock(MqttClient.class)) {
                 mqttBridge =
                         new MQTTBridge(config, mockTopicMapping, mockMessageBridge, mockPubSubIPCAgent, mockIotMqttClient,
-                                mockKernel, mockMqttClientKeyStore, localMqttClientFactory, executor);
+                                mockKernel, mockMqttClientKeyStore, localMqttClientFactory, executor, new BridgeConfigReference());
             }
 
             ClientDevicesAuthService mockClientAuthService = mock(ClientDevicesAuthService.class);
@@ -146,7 +147,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
             try (MqttClient mockIotMqttClient = mock(MqttClient.class)) {
                 mqttBridge =
                         new MQTTBridge(config, mockTopicMapping, mockMessageBridge, mockPubSubIPCAgent, mockIotMqttClient,
-                                mockKernel, mockMqttClientKeyStore, localMqttClientFactory, executor);
+                                mockKernel, mockMqttClientKeyStore, localMqttClientFactory, executor, new BridgeConfigReference());
             }
 
             ClientDevicesAuthService mockClientAuthService = mock(ClientDevicesAuthService.class);
@@ -188,7 +189,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
 
         MQTTBridge mqttBridge =
                 new MQTTBridge(config, mockTopicMapping, mockMessageBridge, mock(PubSubIPCEventStreamAgent.class),
-                        mock(MqttClient.class), mockKernel, mockMqttClientKeyStore, localMqttClientFactory, executor);
+                        mock(MqttClient.class), mockKernel, mockMqttClientKeyStore, localMqttClientFactory, executor, new BridgeConfigReference());
 
         ClientDevicesAuthService mockClientAuthService = mock(ClientDevicesAuthService.class);
         when(mockKernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME))
@@ -217,7 +218,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
 
     static class FakeMqttClientFactory extends LocalMqttClientFactory {
         public FakeMqttClientFactory() {
-            super(null, null);
+            super(null, null, null);
         }
 
         @Override


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Wrap `BridgeConfig` in an atomic reference and inject that wherever config is needed, for convenience.  `MQTTBridge` is responsible for updating the reference

**Why is this change necessary:**
Refactoring now in preparation for using route config within other parts of bridge.  It's easier to use bridge config if we can inject it, rather than using setters and making sure those are all properly called. (e.g. `localMqttClientFactory.setConfig(bridgeConfig);`)

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
