### PR TITLE
fix: unsubscribe from keystore updates

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
@@ -151,6 +151,14 @@ public class MQTTClientKeyStore {
     }
 
     /**
+     * Remove a listener from KeyStore updates.
+     * @param listener listener method
+     */
+    public synchronized void unsubscribeFromCAUpdates(UpdateListener listener) {
+        updateListeners.remove(listener);
+    }
+
+    /**
      * Gets SSL Socket Factory from Key Store.
      *
      * @return SSLSocketFactory

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
@@ -59,6 +59,7 @@ public class MQTTClient implements MessageClient<MqttMessage> {
     private Set<String> subscribedLocalMqttTopics = ConcurrentHashMap.newKeySet();
     private Set<String> toSubscribeLocalMqttTopics = new HashSet<>();
 
+    private final MQTTClientKeyStore.UpdateListener onKeyStoreUpdate = this::reset;
     private final MQTTClientKeyStore mqttClientKeyStore;
 
     private final RetryUtils.RetryConfig mqttExceptionRetryConfig =
@@ -115,7 +116,7 @@ public class MQTTClient implements MessageClient<MqttMessage> {
         this.mqttClientInternal = mqttClient;
         this.dataStore = new MemoryPersistence();
         this.mqttClientKeyStore = mqttClientKeyStore;
-        this.mqttClientKeyStore.listenToCAUpdates(this::reset);
+        this.mqttClientKeyStore.listenToCAUpdates(onKeyStoreUpdate);
         this.executorService = executorService;
     }
 
@@ -155,6 +156,8 @@ public class MQTTClient implements MessageClient<MqttMessage> {
         } catch (MqttException e) {
             LOGGER.atError().setCause(e).log("Failed to disconnect MQTT client");
         }
+
+        mqttClientKeyStore.unsubscribeFromCAUpdates(onKeyStoreUpdate);
     }
 
     private synchronized void removeMappingAndSubscriptions() {

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClientTest.java
@@ -31,7 +31,9 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
@@ -84,6 +86,7 @@ public class MQTTClientTest {
 
         mqttClient.stop();
 
+        verify(mockMqttClientKeyStore).unsubscribeFromCAUpdates(any());
         subscriptions = fakeMqttClient.getSubscriptionTopics();
         assertThat(fakeMqttClient.isConnected(), is(false));
         assertThat(subscriptions, hasSize(0));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Spotted in integration testing, when we switch between local mqtt clients, the old one still gets their `reset` triggered on keystore updates, so we need an unsubscribe mechanism.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
