### PR TITLE
chore: integration test with ssl

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
@@ -14,12 +14,14 @@ import com.aws.greengrass.integrationtests.extensions.BridgeIntegrationTest;
 import com.aws.greengrass.integrationtests.extensions.BridgeIntegrationTestContext;
 import com.aws.greengrass.integrationtests.extensions.Broker;
 import com.aws.greengrass.integrationtests.extensions.TestWithMqtt3Broker;
+import com.aws.greengrass.integrationtests.extensions.TestWithMqtt5Broker;
 import com.aws.greengrass.integrationtests.extensions.WithKernel;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.mqtt.bridge.BridgeConfig;
 import com.aws.greengrass.mqtt.bridge.MQTTBridge;
 import com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.time.Instant;
@@ -69,6 +71,12 @@ public class KeystoreTest {
                 ));
 
         assertTrue(keyStoreUpdated.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    }
+
+    @Disabled("Failed to create new aws_tls_ctx (aws_last_error: AWS_ERROR_SUCCESS(0), Success.)")
+    @TestWithMqtt5Broker
+    @WithKernel("mqtt5_config_ssl.yaml")
+    void GIVEN_mqtt_bridge_with_ssl_WHEN_startup_THEN_success(Broker broker) {
     }
 
     @TestWithMqtt3Broker

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestContext.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestContext.java
@@ -22,7 +22,8 @@ import java.nio.file.Path;
 @Data
 public class BridgeIntegrationTestContext {
     Broker broker;
-    Integer brokerPort;
+    Integer brokerSSLPort;
+    Integer brokerTCPPort;
     String brokerHost;
     Path rootDir;
     Kernel kernel;

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestExtensionTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestExtensionTest.java
@@ -24,7 +24,7 @@ public class BridgeIntegrationTestExtensionTest {
     void GIVEN_mqtt5_broker_WHEN_test_starts_THEN_bridge_connects(Broker broker) {
         assertNotNull(context.getBroker());
         assertNotNull(context.getBrokerHost());
-        assertNotNull(context.getBrokerPort());
+        assertNotNull(context.getBrokerTCPPort());
         assertNotNull(context.getKernel());
         assertNotNull(context.getRootDir());
     }
@@ -34,7 +34,7 @@ public class BridgeIntegrationTestExtensionTest {
     void GIVEN_mqtt3_broker_WHEN_test_starts_THEN_bridge_connects(Broker broker) {
         assertNotNull(context.getBroker());
         assertNotNull(context.getBrokerHost());
-        assertNotNull(context.getBrokerPort());
+        assertNotNull(context.getBrokerTCPPort());
         assertNotNull(context.getKernel());
         assertNotNull(context.getRootDir());
     }
@@ -44,7 +44,7 @@ public class BridgeIntegrationTestExtensionTest {
     void GIVEN_any_broker_WHEN_test_starts_THEN_bridge_connects(Broker broker) {
         assertNotNull(context.getBroker());
         assertNotNull(context.getBrokerHost());
-        assertNotNull(context.getBrokerPort());
+        assertNotNull(context.getBrokerTCPPort());
         assertNotNull(context.getKernel());
         assertNotNull(context.getRootDir());
     }
@@ -54,7 +54,7 @@ public class BridgeIntegrationTestExtensionTest {
     void GIVEN_no_broker_and_no_kernel_WHEN_parameterized_test_executed_THEN_nothing_happens(String unused) {
         assertNull(context.getBroker());
         assertNull(context.getBrokerHost());
-        assertNull(context.getBrokerPort());
+        assertNull(context.getBrokerTCPPort());
         assertNull(context.getKernel());
         assertNotNull(context.getRootDir());
     }
@@ -62,7 +62,7 @@ public class BridgeIntegrationTestExtensionTest {
     void GIVEN_no_broker_and_no_kernel_WHEN_test_executed_THEN_nothing_happens() {
         assertNull(context.getBroker());
         assertNull(context.getBrokerHost());
-        assertNull(context.getBrokerPort());
+        assertNull(context.getBrokerTCPPort());
         assertNull(context.getKernel());
         assertNotNull(context.getRootDir());
     }
@@ -72,7 +72,7 @@ public class BridgeIntegrationTestExtensionTest {
     void GIVEN_kernel_and_no_broker_WHEN_test_starts_THEN_kernel_starts() {
         assertNull(context.getBroker());
         assertNull(context.getBrokerHost());
-        assertNull(context.getBrokerPort());
+        assertNull(context.getBrokerTCPPort());
         assertNotNull(context.getKernel());
         assertNotNull(context.getRootDir());
     }
@@ -83,7 +83,7 @@ public class BridgeIntegrationTestExtensionTest {
     void GIVEN_kernel_and_no_broker_WHEN_parameterized_test_starts_THEN_kernel_starts(String unused) {
         assertNull(context.getBroker());
         assertNull(context.getBrokerHost());
-        assertNull(context.getBrokerPort());
+        assertNull(context.getBrokerTCPPort());
         assertNotNull(context.getKernel());
         assertNotNull(context.getRootDir());
     }
@@ -92,7 +92,7 @@ public class BridgeIntegrationTestExtensionTest {
     void GIVEN_broker_and_no_kernel_WHEN_test_starts_THEN_broker_starts(Broker broker) {
         assertNotNull(context.getBroker());
         assertNotNull(context.getBrokerHost());
-        assertNotNull(context.getBrokerPort());
+        assertNotNull(context.getBrokerTCPPort());
         assertNull(context.getKernel());
         assertNotNull(context.getRootDir());
     }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/Certs.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/Certs.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.extensions;
+
+import com.aws.greengrass.clientdevices.auth.api.CertificateUpdateEvent;
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
+import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
+import com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore;
+import com.aws.greengrass.util.Utils;
+import lombok.Getter;
+import org.bouncycastle.cert.CertIOException;
+import org.bouncycastle.operator.OperatorCreationException;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+import java.util.stream.Stream;
+
+class Certs {
+    private static final Duration CERT_EXPIRY = Duration.ofMinutes(5);
+
+    @Getter
+    private final String serverKeystorePassword = Utils.generateRandomString(20);
+
+    private final KeyPair caKeys;
+    private final X509Certificate caCert;
+    private final KeyPair clientKeyPair;
+    private final X509Certificate clientCert;
+    private final KeyPair serverKeyPair;
+    private final X509Certificate serverCert;
+    private final KeyStore serverKeyStore;
+
+    public Certs(MQTTClientKeyStore clientKeyStore) throws KeyStoreException {
+        try {
+            this.caKeys = genKeys();
+            this.caCert = genCACert(caKeys);
+            this.clientKeyPair = genKeys();
+            this.serverKeyPair = genKeys();
+            this.clientCert = genClientCert(clientKeyPair);
+            this.serverCert = genServerCert(serverKeyPair);
+            initClientKeyStoreWithCerts(clientKeyStore);
+            this.serverKeyStore = createServerKeystore();
+        } catch (CertificateException | IOException | OperatorCreationException
+                 | NoSuchAlgorithmException | CertificateGenerationException e) {
+            throw new KeyStoreException(e);
+        }
+    }
+
+    private X509Certificate genCACert(KeyPair keyPair)
+            throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, CertIOException {
+        Instant now = Instant.now();
+        return CertificateHelper.createCACertificate(
+                keyPair,
+                Date.from(now),
+                Date.from(now.plus(CERT_EXPIRY)),
+                "Greengrass Bridge Integration Test CA"
+        );
+    }
+
+    private KeyPair genKeys() throws NoSuchAlgorithmException {
+        return CertificateStore.newRSAKeyPair(4096);
+    }
+
+    private X509Certificate genServerCert(KeyPair keyPair)
+            throws CertificateException, NoSuchAlgorithmException, IOException, OperatorCreationException {
+        Instant now = Instant.now();
+        return CertificateHelper.issueServerCertificate(
+                caCert,
+                caKeys.getPrivate(),
+                CertificateHelper.getX500Name("mqtt-bridge"),
+                keyPair.getPublic(),
+                Collections.emptyList(),
+                Date.from(now),
+                Date.from(now.plus(CERT_EXPIRY)));
+    }
+
+    private X509Certificate genClientCert(KeyPair keyPair)
+            throws CertificateException, NoSuchAlgorithmException, IOException, OperatorCreationException {
+        Instant now = Instant.now();
+        return CertificateHelper.issueClientCertificate(
+                caCert,
+                caKeys.getPrivate(),
+                CertificateHelper.getX500Name("mqtt-bridge"),
+                keyPair.getPublic(),
+                Date.from(now),
+                Date.from(now.plus(CERT_EXPIRY)));
+    }
+
+    private KeyStore createServerKeystore() throws KeyStoreException {
+        KeyStore serverKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+
+        // create empty keystore
+        try {
+            serverKeyStore.load(null, serverKeystorePassword.toCharArray());
+        } catch (IOException | NoSuchAlgorithmException | CertificateException e) {
+            throw new KeyStoreException("Unable to load keystore", e);
+        }
+
+        // add key and certs to keystore
+        serverKeyStore.setKeyEntry(
+                "hivemq",
+                serverKeyPair.getPrivate(),
+                serverKeystorePassword.toCharArray(),
+                Stream.of(serverCert, caCert).toArray(X509Certificate[]::new)
+        );
+
+        return serverKeyStore;
+    }
+
+    private MQTTClientKeyStore initClientKeyStoreWithCerts(MQTTClientKeyStore clientKeyStore)
+            throws KeyStoreException, CertificateException, IOException, CertificateGenerationException {
+        clientKeyStore.init();
+        clientKeyStore.updateCert(new CertificateUpdateEvent(clientKeyPair, clientCert, new X509Certificate[]{caCert}));
+        clientKeyStore.updateCA(Collections.singletonList(CertificateHelper.toPem(caCert)));
+        return clientKeyStore;
+    }
+
+    public void writeServerKeystore(Path output) throws KeyStoreException {
+        try (OutputStream fos = Files.newOutputStream(output)) {
+            serverKeyStore.store(fos, serverKeystorePassword.toCharArray());
+        } catch (IOException | NoSuchAlgorithmException | CertificateException | KeyStoreException e) {
+            throw new KeyStoreException("unable to write keystore to " + output, e);
+        }
+    }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_config_ssl.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_config_ssl.yaml
@@ -1,0 +1,22 @@
+services:
+aws.greengrass.Nucleus:
+  configuration:
+    logging:
+      level: "DEBUG"
+aws.greengrass.clientdevices.mqtt.Bridge:
+  configuration:
+    brokerUri: "ssl://localhost:8883"
+    mqttTopicMapping:
+      toIotCore:
+        topic: topic/toIotCore
+        source: LocalMqtt
+        target: IotCore
+      toLocal:
+        topic: topic/toLocal
+        source: IotCore
+        target: LocalMqtt
+    brokerClient:
+      version: "mqtt5"
+main:
+  dependencies:
+    - aws.greengrass.clientdevices.mqtt.Bridge

--- a/src/integrationtests/resources/hivemq/config.xml
+++ b/src/integrationtests/resources/hivemq/config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<hivemq>
+    <listeners>
+        <tcp-listener>
+            <port>1883</port>
+            <bind-address>0.0.0.0</bind-address>
+        </tcp-listener>
+        <tls-tcp-listener>
+            <port>8883</port>
+            <bind-address>0.0.0.0</bind-address>
+            <tls>
+                <keystore>
+                    <path>server.jks</path>
+                    <password>${SERVER_JKS_PASSWORD}</password>
+                    <private-key-password>${SERVER_JKS_PASSWORD}</private-key-password>
+                </keystore>
+                <client-authentication-mode>NONE</client-authentication-mode>
+            </tls>
+        </tls-tcp-listener>
+    </listeners>
+</hivemq>

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
@@ -92,7 +92,12 @@ public class MQTTClientKeyStore {
         clientDevicesAuthServiceApi.unsubscribeFromCertificateUpdates(clientCertificateRequest);
     }
 
-    private void updateCert(CertificateUpdateEvent certificateUpdate) {
+    /**
+     * Update keystore entry.
+     *
+     * @param certificateUpdate certificate update event
+     */
+    public void updateCert(CertificateUpdateEvent certificateUpdate) {
         try {
             LOGGER.atDebug().log("Storing new client certificate to be used on next connect attempt");
             X509Certificate[] certChain = Stream.concat(


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Work in progress: Currently, running into crt errors when creating tls context.

Supply HiveMQ with server certs so we can exercise CRT tls setup in integration tests.


**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
