### PR TITLE
fix: null pointer in MQTTClient reset

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
@@ -54,7 +54,7 @@ public class MQTTClient implements MessageClient<MqttMessage> {
     private Future<?> connectFuture;
     private Future<?> subscribeFuture;
     @Getter // for testing
-    private IMqttClient mqttClientInternal;
+    private volatile IMqttClient mqttClientInternal;
     @Getter(AccessLevel.PROTECTED)
     private Set<String> subscribedLocalMqttTopics = ConcurrentHashMap.newKeySet();
     private Set<String> toSubscribeLocalMqttTopics = new HashSet<>();

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
@@ -105,6 +105,7 @@ public class MQTTClient implements MessageClient<MqttMessage> {
         try {
             this.mqttClientInternal = new MqttClient(brokerUri.toString(), clientId, dataStore);
         } catch (MqttException e) {
+            this.mqttClientKeyStore.unsubscribeFromCAUpdates(onKeyStoreUpdate);
             throw new MQTTClientException("Unable to create an MQTT client", e);
         }
     }

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
@@ -121,6 +121,10 @@ public class MQTTClient implements MessageClient<MqttMessage> {
     }
 
     void reset() {
+        if (mqttClientInternal == null) {
+            LOGGER.atDebug().log("Client not yet initialized, skipping reset");
+            return;
+        }
         if (mqttClientInternal.isConnected()) {
             try {
                 mqttClientInternal.disconnect();
@@ -146,8 +150,8 @@ public class MQTTClient implements MessageClient<MqttMessage> {
      */
     @Override
     public void stop() {
+        mqttClientKeyStore.unsubscribeFromCAUpdates(onKeyStoreUpdate);
         removeMappingAndSubscriptions();
-
         try {
             if (mqttClientInternal.isConnected()) {
                 mqttClientInternal.disconnect();
@@ -156,8 +160,6 @@ public class MQTTClient implements MessageClient<MqttMessage> {
         } catch (MqttException e) {
             LOGGER.atError().setCause(e).log("Failed to disconnect MQTT client");
         }
-
-        mqttClientKeyStore.unsubscribeFromCAUpdates(onKeyStoreUpdate);
     }
 
     private synchronized void removeMappingAndSubscriptions() {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Fix a null pointer when `MQTTClient#reset` is invoked before `MQTTClient` constructor completes

As seen in https://github.com/aws-greengrass/aws-greengrass-mqtt-bridge/pull/113 test runs:
```
2023-03-29T23:12:31.7379239Z 2023-03-29T23:12:29.496Z [ERROR] (Serialized listener processor) com.aws.greengrass.dependency.Context: run-on-publish-queue-error. {}
2023-03-29T23:12:31.7379638Z java.lang.NullPointerException
2023-03-29T23:12:31.7379989Z 	at com.aws.greengrass.mqtt.bridge.clients.MQTTClient.reset(MQTTClient.java:124)
2023-03-29T23:12:31.7380464Z 	at java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:895)
2023-03-29T23:12:31.7380944Z 	at java.util.concurrent.CopyOnWriteArraySet.forEach(CopyOnWriteArraySet.java:404)
2023-03-29T23:12:31.7381442Z 	at com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore.updateCA(MQTTClientKeyStore.java:132)
2023-03-29T23:12:31.7382001Z 	at com.aws.greengrass.mqtt.bridge.MQTTBridge$CertificateAuthorityChangeHandler.updateCA(MQTTBridge.java:207)
2023-03-29T23:12:31.7382600Z 	at java.util.Optional.ifPresent(Optional.java:159)
2023-03-29T23:12:31.7383207Z 	at com.aws.greengrass.mqtt.bridge.MQTTBridge$CertificateAuthorityChangeHandler.onCAChange(MQTTBridge.java:186)
2023-03-29T23:12:31.7383777Z 	at com.aws.greengrass.mqtt.bridge.MQTTBridge$CertificateAuthorityChangeHandler.lambda$start$0(MQTTBridge.java:168)
2023-03-29T23:12:31.7384317Z 	at com.aws.greengrass.util.BatchedSubscriber.lambda$onChange$1(BatchedSubscriber.java:169)
2023-03-29T23:12:31.7384748Z 	at com.aws.greengrass.dependency.Context$1.run(Context.java:68)
```

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
