### PR TITLE
fix: add ca cert to mqtt5client

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
@@ -24,6 +24,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -41,8 +42,8 @@ import javax.net.ssl.TrustManagerFactory;
 
 public class MQTTClientKeyStore {
     private static final Logger LOGGER = LogManager.getLogger(MQTTClientKeyStore.class);
-    public static final char[] DEFAULT_KEYSTORE_PASSWORD = "".toCharArray();
-    public static final String KEY_ALIAS = "aws-greengrass-mqttbridge";
+    static final char[] DEFAULT_KEYSTORE_PASSWORD = "".toCharArray();
+    static final String KEY_ALIAS = "aws-greengrass-mqttbridge";
 
     @Getter
     private KeyStore keyStore;
@@ -178,5 +179,28 @@ public class MQTTClientKeyStore {
         } catch (NoSuchAlgorithmException | UnrecoverableKeyException | KeyManagementException e) {
             throw new KeyStoreException("Unable to create SocketFactory from KeyStore", e);
         }
+    }
+
+    /**
+     * Retrieve the client cert from the keystore.
+     *
+     * @return PEM-encoded certificate
+     * @throws KeyStoreException if keystore has not been initialized
+     * @throws CertificateEncodingException if encoding error occurs
+     */
+    public String getCertificate() throws KeyStoreException, CertificateEncodingException {
+        return new String(keyStore.getCertificate(KEY_ALIAS).getEncoded());
+    }
+
+    /**
+     * Retrieve the client private key from the keystore.
+     *
+     * @return private key
+     * @throws UnrecoverableKeyException if the key cannot be recovered
+     * @throws KeyStoreException if the keystore has not been initialized
+     * @throws NoSuchAlgorithmException  if the algorithm for recovering the key cannot be found
+     */
+    public String getPrivateKey() throws UnrecoverableKeyException, KeyStoreException, NoSuchAlgorithmException {
+        return new String(keyStore.getKey(KEY_ALIAS, DEFAULT_KEYSTORE_PASSWORD).getEncoded());
     }
 }

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
@@ -24,14 +24,11 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Optional;
@@ -46,6 +43,8 @@ import javax.net.ssl.TrustManagerFactory;
 
 public class MQTTClientKeyStore {
     private static final Logger LOGGER = LogManager.getLogger(MQTTClientKeyStore.class);
+    private static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
+    private static final String END_CERT = "-----END CERTIFICATE-----";
     public static final char[] DEFAULT_KEYSTORE_PASSWORD = "".toCharArray();
     public static final String KEY_ALIAS = "aws-greengrass-mqttbridge";
 
@@ -53,6 +52,7 @@ public class MQTTClientKeyStore {
     private KeyStore keyStore;
     private final ClientDevicesAuthServiceApi clientDevicesAuthServiceApi;
     private final Set<UpdateListener> updateListeners = new CopyOnWriteArraySet<>();
+    private final List<String> caCerts = new ArrayList<>();
     private final GetCertificateRequest clientCertificateRequest;
 
     @FunctionalInterface
@@ -128,49 +128,50 @@ public class MQTTClientKeyStore {
                 keyStore.deleteEntry(alias);
             }
         }
-
         for (int i = 0; i < caCerts.size(); i++) {
             X509Certificate caCert = pemToX509Certificate(caCerts.get(i));
             keyStore.setCertificateEntry("CA" + i, caCert);
         }
-
+        setCaCerts(caCerts);
         updateListeners.forEach(UpdateListener::onCAUpdate); //notify MQTTClient
     }
 
-    /**
-     * Get the CA cert chain from the key store.
-     *
-     * @return ca cert chain
-     * @throws KeyStoreException if keystore has not been initialized
-     * @throws CertificateEncodingException if an encoding error occurs
-     */
-    @SuppressWarnings("PMD.InsufficientStringBufferDeclaration")
-    public Optional<String> getCACertChain() throws KeyStoreException, CertificateEncodingException {
-        List<Certificate> caCerts = getCACerts();
-        if (caCerts.isEmpty()) {
-            return Optional.empty();
+    private void setCaCerts(List<String> caCerts) {
+        synchronized (this.caCerts) {
+            this.caCerts.clear();
+            this.caCerts.addAll(caCerts);
         }
-        StringBuilder chain = new StringBuilder("-----BEGIN CERTIFICATE-----");
-        for (Certificate cert : caCerts) {
-            String encodedCert = Base64.getEncoder().encodeToString(cert.getEncoded());
-            chain.append(System.lineSeparator())
-                    .append(encodedCert);
-        }
-        return Optional.of(chain.append(System.lineSeparator())
-                .append("-----END CERTIFICATE-----")
-                .toString());
     }
 
-    private List<Certificate> getCACerts() throws KeyStoreException {
-        List<Certificate> certs = new ArrayList<>();
-        for (int certInd = 0; ; certInd++) {
-            Certificate cert = keyStore.getCertificate("CA" + certInd);
-            if (cert == null) {
-                break;
-            }
-            certs.add(cert);
+    private List<String> getCaCerts() {
+        synchronized (caCerts) {
+            return new ArrayList<>(caCerts);
         }
-        return certs;
+    }
+
+    /**
+     * Return CA cert chain as a string.
+     *
+     * @return ca certs
+     */
+    public Optional<String> getCaCertsAsString() {
+        List<String> certs = getCaCerts();
+        if (certs.isEmpty()) {
+            return Optional.empty();
+        }
+        StringBuilder result = new StringBuilder(BEGIN_CERT);
+        for (String cert : certs) {
+            String trimmedCert = cert
+                    .replace(BEGIN_CERT, "")
+                    .replace(END_CERT, "")
+                    .trim();
+            result.append(System.lineSeparator())
+                    .append(trimmedCert);
+        }
+        return Optional.of(result
+                .append(System.lineSeparator())
+                .append(END_CERT)
+                .toString());
     }
 
     private X509Certificate pemToX509Certificate(String certPem) throws IOException, CertificateException {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
@@ -140,7 +140,7 @@ public class MQTTClientKeyStore {
     }
 
     private synchronized List<String> getCaCerts() {
-        return new ArrayList<>(caCerts);
+        return caCerts;
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationExce
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.mqtt.bridge.MQTTBridge;
+import jdk.internal.joptsimple.internal.Strings;
 import lombok.Getter;
 
 import java.io.ByteArrayInputStream;
@@ -43,8 +44,6 @@ import javax.net.ssl.TrustManagerFactory;
 
 public class MQTTClientKeyStore {
     private static final Logger LOGGER = LogManager.getLogger(MQTTClientKeyStore.class);
-    private static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
-    private static final String END_CERT = "-----END CERTIFICATE-----";
     public static final char[] DEFAULT_KEYSTORE_PASSWORD = "".toCharArray();
     public static final String KEY_ALIAS = "aws-greengrass-mqttbridge";
 
@@ -154,19 +153,7 @@ public class MQTTClientKeyStore {
         if (certs.isEmpty()) {
             return Optional.empty();
         }
-        StringBuilder result = new StringBuilder(BEGIN_CERT);
-        for (String cert : certs) {
-            String trimmedCert = cert
-                    .replace(BEGIN_CERT, "")
-                    .replace(END_CERT, "")
-                    .trim();
-            result.append(System.lineSeparator())
-                    .append(trimmedCert);
-        }
-        return Optional.of(result
-                .append(System.lineSeparator())
-                .append(END_CERT)
-                .toString());
+        return Optional.of(Strings.join(certs,""));
     }
 
     private X509Certificate pemToX509Certificate(String certPem) throws IOException, CertificateException {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
@@ -13,7 +13,6 @@ import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationExce
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.mqtt.bridge.MQTTBridge;
-import jdk.internal.joptsimple.internal.Strings;
 import lombok.Getter;
 
 import java.io.ByteArrayInputStream;
@@ -153,7 +152,7 @@ public class MQTTClientKeyStore {
         if (certs.isEmpty()) {
             return Optional.empty();
         }
-        return Optional.of(Strings.join(certs,""));
+        return Optional.of(String.join("", certs));
     }
 
     private X509Certificate pemToX509Certificate(String certPem) throws IOException, CertificateException {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStore.java
@@ -52,7 +52,7 @@ public class MQTTClientKeyStore {
     private KeyStore keyStore;
     private final ClientDevicesAuthServiceApi clientDevicesAuthServiceApi;
     private final Set<UpdateListener> updateListeners = new CopyOnWriteArraySet<>();
-    private final List<String> caCerts = new ArrayList<>();
+    private List<String> caCerts = new ArrayList<>();
     private final GetCertificateRequest clientCertificateRequest;
 
     @FunctionalInterface
@@ -136,17 +136,12 @@ public class MQTTClientKeyStore {
         updateListeners.forEach(UpdateListener::onCAUpdate); //notify MQTTClient
     }
 
-    private void setCaCerts(List<String> caCerts) {
-        synchronized (this.caCerts) {
-            this.caCerts.clear();
-            this.caCerts.addAll(caCerts);
-        }
+    private synchronized void setCaCerts(List<String> caCerts) {
+        this.caCerts = caCerts;
     }
 
-    private List<String> getCaCerts() {
-        synchronized (caCerts) {
-            return new ArrayList<>(caCerts);
-        }
+    private synchronized List<String> getCaCerts() {
+        return new ArrayList<>(caCerts);
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -503,9 +503,9 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
                 tlsContextOptions = TlsContextOptions.createWithMtlsJavaKeystore(
                         mqttClientKeyStore.getKeyStore(), KEY_ALIAS, new String(DEFAULT_KEYSTORE_PASSWORD));
                 tlsContextOptions.overrideDefaultTrustStore(
-                        mqttClientKeyStore.getRootCACert().orElseThrow(
+                        mqttClientKeyStore.getCACertChain().orElseThrow(
                                 () -> new MQTTClientException("unable to set default trust store, "
-                                        + "root ca cert not found")));
+                                        + "no ca cert found")));
                 tlsContext = new ClientTlsContext(tlsContextOptions);
                 builder.withTlsContext(tlsContext);
             }

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -13,7 +13,6 @@ import com.aws.greengrass.util.Utils;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.Setter;
 import software.amazon.awssdk.crt.CRT;
 import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.io.ClientTlsContext;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Was seeing tls negotiation failed errors in UAT.  Some research led to https://github.com/aws/aws-iot-device-sdk-java-v2/commit/a27d4c8deb86b6c9fbb036aff3095da8b4391ca6, so was able to get UAT to pass when configuring this option.

**Why is this change necessary:**

**How was this change tested:**
UAT
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
