### PR TITLE
feat: handle retries on unsuback reason codes

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -437,8 +437,9 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
                         .log("Successfully subscribed to topic");
             } else if (subAckPacket.getReasonCodes().stream().allMatch(this::retrySubscribe)) {
                 // subscription failed with a retryable reason code, throw exception to trigger RetryUtils
-                throw new RetryableMqttOperationException("Failed to subscribe to " + topic + " with reason codes "
-                        + subAckPacket.getReasonCodes() + ": " + subAckPacket.getReasonString());
+                int rc = subAckPacket.getReasonCodes().stream().findFirst().get().getValue();
+                throw new RetryableMqttOperationException(String.format("Failed to subscribe to %s with reason code "
+                                + "%d: %s", topic, rc, subAckPacket.getReasonString()));
             } else {
                 // subscription failed with a non-retryable reason code
                 LOGGER.atError()
@@ -488,8 +489,9 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
                 LOGGER.atDebug().kv(LOG_KEY_TOPIC, topic).log("Unsubscribed from topic");
             } else if (unsubAckPacket.getReasonCodes().stream().allMatch(this::retryUnsubscribe)) {
                 // failed to unsubscribe with a retryable reason code, throw exception to trigger RetryUtils
-                throw new RetryableMqttOperationException("Failed to unsubscribe from " + topic + " with reason codes "
-                    + unsubAckPacket.getReasonCodes() + ": " + unsubAckPacket.getReasonString());
+                int rc = unsubAckPacket.getReasonCodes().stream().findFirst().get().getValue();
+                throw new RetryableMqttOperationException(String.format("Failed to unsubscribe from %s with reason "
+                        + "code %d: %s", topic, rc, unsubAckPacket.getReasonString()));
             } else {
                 // failed to unsubscribe with a non-retryable reason code
                 LOGGER.atDebug()

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
@@ -219,7 +219,7 @@ class LocalMqtt5ClientTest {
         clientSpy.updateSubscriptions(topics, message -> {});
 
         // verify subscriptions were made
-        assertThat("subscribed topics local client", () -> clientSpy.getSubscribedLocalMqttTopics(),
+        assertThat("subscribed topics local client", clientSpy::getSubscribedLocalMqttTopics,
                 eventuallyEval(is(topics)));
         assertThat("subscribed topics mock client", this::getMockSubscriptions, eventuallyEval(is(topics)));
 
@@ -236,7 +236,7 @@ class LocalMqtt5ClientTest {
         expectedSubscriptions.add("iotcore/topic2");
 
         // verify subscriptions were made
-        assertThat("subscribed topics local client", () -> clientSpy.getSubscribedLocalMqttTopics(),
+        assertThat("subscribed topics local client", clientSpy::getSubscribedLocalMqttTopics,
                 eventuallyEval(is(expectedSubscriptions)));
         assertThat("subscribed topics mock client", this::getMockSubscriptions,
                 eventuallyEval(is(expectedSubscriptions)));


### PR DESCRIPTION
**Issue #, if available:**
Adding handling for UnSubAck reason codes. If the reason codes indicate a success or a non-retryable error, then it will not attempt to unsubscribe from the topic again. Otherwise the it will be retried according to the set RetryUtils configuration. 

**Why is this change necessary:**
Previously, no unsubscribe errors were being retried on. This change will retry on errors that have the possibility of succeeding on consecutive runs.

**How was this change tested:**
Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
