### PR TITLE
feat: handle retries on suback reason codes

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -339,7 +339,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
     }
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    void subscribeToTopics(Set<String> topics) {
+    private void subscribeToTopics(Set<String> topics) {
         for (String topic : topics) {
             try {
                 RetryUtils.runWithRetry(mqttExceptionRetryConfig, () -> {
@@ -389,6 +389,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
                         .kv(LOG_KEY_REASON, subAckPacket.getReasonString())
                         .kv(LOG_KEY_TOPIC, topic)
                         .log("Failed to subscribe to topic");
+                // throw exception to trigger RetryUtils
                 throw new CrtRuntimeException("Failed to subscribe to topic");
             }
         } catch (TimeoutException | ExecutionException e) {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -112,7 +112,8 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
     private final Set<String> subscribedLocalMqttTopics = new HashSet<>();
     @Getter(AccessLevel.PACKAGE) // for testing
     private final Set<String> toSubscribeLocalMqttTopics = new HashSet<>();
-    private final Set<Integer> nonRetryableSubAckReasonCodes = new HashSet<Integer>(){{
+    @SuppressWarnings("PMD.DoubleBraceInitialization")
+    private final Set<Integer> nonRetryableSubAckReasonCodes = new HashSet<Integer>() {{
        this.add(SubAckPacket.SubAckReasonCode.NOT_AUTHORIZED.getValue());
        this.add(SubAckPacket.SubAckReasonCode.TOPIC_FILTER_INVALID.getValue());
        this.add(SubAckPacket.SubAckReasonCode.SHARED_SUBSCRIPTIONS_NOT_SUPPORTED.getValue());

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/RetryableMqttOperationException.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/RetryableMqttOperationException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqtt.bridge.clients;
+
+/**
+ * Exception thrown by the local mqtt5 client to retry operations.
+ */
+public class RetryableMqttOperationException extends MessageClientException {
+    static final long serialVersionUID = -3387516993124229948L;
+
+    RetryableMqttOperationException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    RetryableMqttOperationException(String msg) {
+        super(msg);
+    }
+}

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
@@ -10,14 +10,11 @@ import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.mqtt5.Mqtt5Client;
 import software.amazon.awssdk.crt.mqtt5.Mqtt5ClientOptions;
@@ -26,7 +23,6 @@ import software.amazon.awssdk.crt.mqtt5.OnConnectionFailureReturn;
 import software.amazon.awssdk.crt.mqtt5.OnConnectionSuccessReturn;
 import software.amazon.awssdk.crt.mqtt5.OnDisconnectionReturn;
 import software.amazon.awssdk.crt.mqtt5.OnStoppedReturn;
-import software.amazon.awssdk.crt.mqtt5.QOS;
 import software.amazon.awssdk.crt.mqtt5.packets.ConnAckPacket;
 import software.amazon.awssdk.crt.mqtt5.packets.DisconnectPacket;
 import software.amazon.awssdk.crt.mqtt5.packets.PubAckPacket;
@@ -36,14 +32,10 @@ import software.amazon.awssdk.crt.mqtt5.packets.SubscribePacket;
 import software.amazon.awssdk.crt.mqtt5.packets.UnsubAckPacket;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
@@ -54,18 +46,14 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-//@MockitoSettings(strictness = Strictness.LENIENT)
 class LocalMqtt5ClientTest {
 
     ExecutorService executorService = TestUtils.synchronousExecutorService();


### PR DESCRIPTION
**Description of changes:**
Adding handling for SubAck reason codes. If the reason codes indicate a success or a non-retryable error (such as not being authorized), then the subscription will not be retried. Otherwise the subscription will be retried according to the set RetryUtils configuration. 

**Why is this change necessary:**
Previously, no subscriptions errors were being retried on. This change will retry on errors that have the possibility of succeeding on consecutive runs.

**How was this change tested:**
Unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
