### PR TITLE
chore: make client timeouts configurable

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -24,6 +24,7 @@ import lombok.ToString;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,6 +46,11 @@ public final class BridgeConfig {
     static final String KEY_BROKER_SERVER_URI = "brokerServerUri"; // for backwards compatibility only
     public static final String KEY_BROKER_URI = "brokerUri";
     public static final String KEY_CLIENT_ID = "clientId";
+    static final String KEY_ACK_TIMEOUT_SECONDS = "ackTimeoutSeconds";
+    static final String KEY_CONNACK_TIMEOUT_MS = "connAckTimeoutMs";
+    static final String KEY_PING_TIMEOUT_MS = "pingTimeoutMs";
+    static final String KEY_MAX_RECONNECT_DELAY_MS = "maxReconnectDelayMs";
+    static final String KEY_MIN_RECONNECT_DELAY_MS = "minReconnectDelayMs";
     public static final String KEY_MQTT_TOPIC_MAPPING = "mqttTopicMapping";
     static final String KEY_MQTT_5_ROUTE_OPTIONS = "mqtt5RouteOptions";
     static final String KEY_BROKER_CLIENT = "brokerClient";
@@ -53,11 +59,13 @@ public final class BridgeConfig {
     static final String KEY_MAXIMUM_PACKET_SIZE = "maximumPacketSize";
     static final String KEY_SESSION_EXPIRY_INTERVAL = "sessionExpiryInterval";
 
+
+    private static final long MIN_TIMEOUT = 0L;
     private static final int MIN_RECEIVE_MAXIMUM = 1;
     private static final int MAX_RECEIVE_MAXIMUM = 65_535;
-    private static final long MIN_MAXIMUM_PACKET_SIZE = 1;
+    private static final long MIN_MAXIMUM_PACKET_SIZE = 1L;
     private static final long MAX_MAXIMUM_PACKET_SIZE = 4_294_967_295L;
-    private static final long MIN_SESSION_EXPIRY_INTERVAL = 0;
+    private static final long MIN_SESSION_EXPIRY_INTERVAL = 0L;
     private static final long MAX_SESSION_EXPIRY_INTERVAL = 4_294_967_295L;
 
     private static final String DEFAULT_BROKER_URI = "ssl://localhost:8883";
@@ -66,10 +74,19 @@ public final class BridgeConfig {
     private static final int DEFAULT_RECEIVE_MAXIMUM = MAX_RECEIVE_MAXIMUM;
     private static final Long DEFAULT_MAXIMUM_PACKET_SIZE = null;
     private static final long DEFAULT_SESSION_EXPIRY_INTERVAL = MAX_SESSION_EXPIRY_INTERVAL;
-
+    private static final long DEFAULT_ACK_TIMEOUT_SECONDS = 60L;
+    private static final long DEFAULT_CONNACK_TIMEOUT_MS = Duration.ofSeconds(20).toMillis();
+    private static final long DEFAULT_PING_TIMEOUT_MS = Duration.ofSeconds(30).toMillis();
+    private static final long DEFAULT_MAX_RECONNECT_DELAY_MS = Duration.ofSeconds(120).toMillis();
+    private static final long DEFAULT_MIN_RECONNECT_DELAY_MS = Duration.ofSeconds(1).toMillis();
 
     private final URI brokerUri;
     private final String clientId;
+    private final long ackTimeoutSeconds;
+    private final long connAckTimeoutMs;
+    private final long pingTimeoutMs;
+    private final long maxReconnectDelayMs;
+    private final long minReconnectDelayMs;
     private final Map<String, TopicMapping.MappingEntry> topicMapping;
     private final Map<String, Mqtt5RouteOptions> mqtt5RouteOptions;
     private final MqttVersion mqttVersion;
@@ -87,9 +104,21 @@ public final class BridgeConfig {
      */
     @SuppressWarnings("PMD.PrematureDeclaration")
     public static BridgeConfig fromTopics(Topics configurationTopics) throws InvalidConfigurationException {
+        long maxReconnectDelayMs = getMaxReconnectDelayMs(configurationTopics);
+        long minReconnectDelayMs = getMinReconnectDelayMs(configurationTopics);
+        if (maxReconnectDelayMs < minReconnectDelayMs) {
+            throw new InvalidConfigurationException(
+                    "maxReconnectDelayMs must be greater than or equal to minReconnectDelayMs");
+        }
+
         return BridgeConfig.builder()
                 .brokerUri(getBrokerUri(configurationTopics))
                 .clientId(getClientId(configurationTopics))
+                .ackTimeoutSeconds(getAckTimeoutSeconds(configurationTopics))
+                .connAckTimeoutMs(getConnAckTimeoutMs(configurationTopics))
+                .pingTimeoutMs(getPingTimeoutMs(configurationTopics))
+                .maxReconnectDelayMs(maxReconnectDelayMs)
+                .minReconnectDelayMs(minReconnectDelayMs)
                 .topicMapping(getTopicMapping(configurationTopics))
                 .mqtt5RouteOptions(getMqtt5RouteOptions(configurationTopics))
                 .mqttVersion(getMqttVersion(configurationTopics))
@@ -114,6 +143,61 @@ public final class BridgeConfig {
 
     private static String getClientId(Topics configurationTopics) {
         return Coerce.toString(configurationTopics.findOrDefault(DEFAULT_CLIENT_ID, KEY_CLIENT_ID));
+    }
+
+    private static long getAckTimeoutSeconds(Topics configurationTopics) {
+        long ackTimeoutSeconds = Coerce.toLong(configurationTopics.findOrDefault(DEFAULT_ACK_TIMEOUT_SECONDS,
+                KEY_BROKER_CLIENT, KEY_ACK_TIMEOUT_SECONDS));
+        if (ackTimeoutSeconds < MIN_TIMEOUT) {
+            LOGGER.atWarn().kv(KEY_ACK_TIMEOUT_SECONDS, ackTimeoutSeconds)
+                    .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_ACK_TIMEOUT_SECONDS, DEFAULT_ACK_TIMEOUT_SECONDS);
+            return DEFAULT_ACK_TIMEOUT_SECONDS;
+        }
+        return ackTimeoutSeconds;
+    }
+
+    private static long getConnAckTimeoutMs(Topics configurationTopics) {
+        long connackTimeoutSeconds = Coerce.toLong(configurationTopics.findOrDefault(DEFAULT_CONNACK_TIMEOUT_MS,
+                KEY_BROKER_CLIENT, KEY_CONNACK_TIMEOUT_MS));
+        if (connackTimeoutSeconds < MIN_TIMEOUT) {
+            LOGGER.atWarn().kv(KEY_CONNACK_TIMEOUT_MS, connackTimeoutSeconds)
+                    .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_CONNACK_TIMEOUT_MS, DEFAULT_CONNACK_TIMEOUT_MS);
+            return DEFAULT_CONNACK_TIMEOUT_MS;
+        }
+        return connackTimeoutSeconds;
+    }
+
+    private static long getPingTimeoutMs(Topics configurationTopics) {
+        long pingTimeoutMs = Coerce.toLong(configurationTopics.findOrDefault(DEFAULT_PING_TIMEOUT_MS,
+                KEY_BROKER_CLIENT, KEY_PING_TIMEOUT_MS));
+        if (pingTimeoutMs < MIN_TIMEOUT) {
+            LOGGER.atWarn().kv(KEY_PING_TIMEOUT_MS, pingTimeoutMs)
+                    .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_PING_TIMEOUT_MS, DEFAULT_PING_TIMEOUT_MS);
+            return DEFAULT_PING_TIMEOUT_MS;
+        }
+        return pingTimeoutMs;
+    }
+
+    private static long getMaxReconnectDelayMs(Topics configurationTopics) {
+        long maxReconnectDelayMs = Coerce.toLong(configurationTopics.findOrDefault(DEFAULT_MAX_RECONNECT_DELAY_MS,
+                KEY_BROKER_CLIENT, KEY_MAX_RECONNECT_DELAY_MS));
+        if (maxReconnectDelayMs < MIN_TIMEOUT) {
+            LOGGER.atWarn().kv(KEY_MAX_RECONNECT_DELAY_MS, maxReconnectDelayMs)
+                    .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_MAX_RECONNECT_DELAY_MS, DEFAULT_MAX_RECONNECT_DELAY_MS);
+            return DEFAULT_MAX_RECONNECT_DELAY_MS;
+        }
+        return maxReconnectDelayMs;
+    }
+
+    private static long getMinReconnectDelayMs(Topics configurationTopics) {
+        long minReconnectDelayMs = Coerce.toLong(configurationTopics.findOrDefault(DEFAULT_MIN_RECONNECT_DELAY_MS,
+                KEY_BROKER_CLIENT, KEY_MIN_RECONNECT_DELAY_MS));
+        if (minReconnectDelayMs < MIN_TIMEOUT) {
+            LOGGER.atWarn().kv(KEY_MIN_RECONNECT_DELAY_MS, minReconnectDelayMs)
+                    .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_MIN_RECONNECT_DELAY_MS, DEFAULT_MIN_RECONNECT_DELAY_MS);
+            return DEFAULT_MIN_RECONNECT_DELAY_MS;
+        }
+        return minReconnectDelayMs;
     }
 
     private static Map<String, TopicMapping.MappingEntry> getTopicMapping(Topics configurationTopics)

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -77,7 +77,7 @@ public final class BridgeConfig {
     private static final long DEFAULT_ACK_TIMEOUT_SECONDS = 60L;
     private static final long DEFAULT_CONNACK_TIMEOUT_MS = Duration.ofSeconds(20).toMillis();
     private static final long DEFAULT_PING_TIMEOUT_MS = Duration.ofSeconds(30).toMillis();
-    private static final long DEFAULT_MAX_RECONNECT_DELAY_MS = Duration.ofSeconds(120).toMillis();
+    private static final long DEFAULT_MAX_RECONNECT_DELAY_MS = Duration.ofSeconds(30).toMillis();
     private static final long DEFAULT_MIN_RECONNECT_DELAY_MS = Duration.ofSeconds(1).toMillis();
 
     private final URI brokerUri;

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -60,8 +60,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -450,8 +450,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
                 .build();
         LOGGER.atDebug().kv(LOG_KEY_TOPIC, topic).log("Subscribing to MQTT topic");
         try {
-            SubAckPacket subAckPacket = client.subscribe(subscribePacket)
-                    .get(ackTimeoutSeconds, TimeUnit.SECONDS);
+            SubAckPacket subAckPacket = client.subscribe(subscribePacket).get();
             if (subAckPacket.getReasonCodes().stream().allMatch(this::subscriptionIsSuccessful)) {
                 // subscription succeeded
                 synchronized (subscriptionsLock) {
@@ -475,7 +474,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
                         .kv(LOG_KEY_TOPIC, topic)
                         .log("Failed to subscribe to topic with a non-retryable reason code, not retrying");
             }
-        } catch (TimeoutException | ExecutionException e) {
+        } catch (ExecutionException e) {
             LOGGER.atError().setCause(Utils.getUltimateCause(e)).kv(LOG_KEY_TOPIC, topic)
                     .log("Failed to subscribe to topic");
         } catch (InterruptedException e) {
@@ -509,8 +508,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
                 new UnsubscribePacket.UnsubscribePacketBuilder().withSubscription(topic).build();
         LOGGER.atDebug().kv(LOG_KEY_TOPIC, topic).log("Unsubscribing from MQTT topic");
         try {
-            UnsubAckPacket unsubAckPacket = client.unsubscribe(unsubscribePacket)
-                    .get(ackTimeoutSeconds, TimeUnit.SECONDS);
+            UnsubAckPacket unsubAckPacket = client.unsubscribe(unsubscribePacket).get();
             if (unsubAckPacket.getReasonCodes().stream().allMatch(this::unsubscribeIsSuccessful)) {
                 // successfully unsubscribed
                 LOGGER.atDebug().kv(LOG_KEY_TOPIC, topic).log("Unsubscribed from topic");
@@ -531,7 +529,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
             synchronized (subscriptionsLock) {
                 subscribedLocalMqttTopics.remove(topic);
             }
-        } catch (TimeoutException | ExecutionException e) {
+        } catch (ExecutionException e) {
             LOGGER.atError().setCause(Utils.getUltimateCause(e)).kv(LOG_KEY_TOPIC, topic)
                     .log("failed to unsubscribe");
         } catch (InterruptedException e) {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -451,7 +451,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
         LOGGER.atDebug().kv(LOG_KEY_TOPIC, topic).log("Subscribing to MQTT topic");
         try {
             SubAckPacket subAckPacket = client.subscribe(subscribePacket)
-                    .get(ackTimeoutSeconds, TimeUnit.MILLISECONDS);
+                    .get(ackTimeoutSeconds, TimeUnit.SECONDS);
             if (subAckPacket.getReasonCodes().stream().allMatch(this::subscriptionIsSuccessful)) {
                 // subscription succeeded
                 synchronized (subscriptionsLock) {
@@ -510,7 +510,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
         LOGGER.atDebug().kv(LOG_KEY_TOPIC, topic).log("Unsubscribing from MQTT topic");
         try {
             UnsubAckPacket unsubAckPacket = client.unsubscribe(unsubscribePacket)
-                    .get(ackTimeoutSeconds, TimeUnit.MILLISECONDS);
+                    .get(ackTimeoutSeconds, TimeUnit.SECONDS);
             if (unsubAckPacket.getReasonCodes().stream().allMatch(this::unsubscribeIsSuccessful)) {
                 // successfully unsubscribed
                 LOGGER.atDebug().kv(LOG_KEY_TOPIC, topic).log("Unsubscribed from topic");

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
@@ -53,6 +53,11 @@ public class LocalMqttClientFactory {
                 return new LocalMqtt5Client(
                         config.getBrokerUri(),
                         config.getClientId(),
+                        config.getAckTimeoutSeconds(),
+                        config.getConnAckTimeoutMs(),
+                        config.getPingTimeoutMs(),
+                        config.getMaxReconnectDelayMs(),
+                        config.getMinReconnectDelayMs(),
                         config.getMqtt5RouteOptionsForSource(TopicMapping.TopicType.LocalMqtt),
                         mqttClientKeyStore,
                         executorService

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -42,7 +42,7 @@ class BridgeConfigTest {
     private static final long DEFAULT_ACK_TIMEOUT_SECONDS = 60L;
     private static final long DEFAULT_CONNACK_TIMEOUT_MS = 20000L;
     private static final long DEFAULT_PING_TIMEOUT_MS = 30000L;
-    private static final long DEFAULT_MAX_RECONNECT_DELAY_MS = 120000L;
+    private static final long DEFAULT_MAX_RECONNECT_DELAY_MS = 30000L;
     private static final long DEFAULT_MIN_RECONNECT_DELAY_MS = 1000L;
     private static final String BROKER_URI = "tcp://localhost:8883";
     private static final String BROKER_SERVER_URI = "tcp://localhost:8884";

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -39,6 +39,11 @@ class BridgeConfigTest {
     private static final int DEFAULT_RECEIVE_MAXIMUM = 65535;
     private static final Long DEFAULT_MAXIMUM_PACKET_SIZE = null;
     private static final long DEFAULT_SESSION_EXPIRY_INTERVAL = 4_294_967_295L;
+    private static final long DEFAULT_ACK_TIMEOUT_SECONDS = 60L;
+    private static final long DEFAULT_CONNACK_TIMEOUT_MS = 20000L;
+    private static final long DEFAULT_PING_TIMEOUT_MS = 30000L;
+    private static final long DEFAULT_MAX_RECONNECT_DELAY_MS = 120000L;
+    private static final long DEFAULT_MIN_RECONNECT_DELAY_MS = 1000L;
     private static final String BROKER_URI = "tcp://localhost:8883";
     private static final String BROKER_SERVER_URI = "tcp://localhost:8884";
     private static final String MALFORMED_BROKER_URI = "tcp://ma]formed.uri:8883";
@@ -52,6 +57,11 @@ class BridgeConfigTest {
             .receiveMaximum(DEFAULT_RECEIVE_MAXIMUM)
             .maximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE)
             .sessionExpiryInterval(DEFAULT_SESSION_EXPIRY_INTERVAL)
+            .ackTimeoutSeconds(DEFAULT_ACK_TIMEOUT_SECONDS)
+            .connAckTimeoutMs(DEFAULT_CONNACK_TIMEOUT_MS)
+            .pingTimeoutMs(DEFAULT_PING_TIMEOUT_MS)
+            .maxReconnectDelayMs(DEFAULT_MAX_RECONNECT_DELAY_MS)
+            .minReconnectDelayMs(DEFAULT_MIN_RECONNECT_DELAY_MS)
             .build();
 
     Topics topics;
@@ -130,6 +140,83 @@ class BridgeConfigTest {
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(CLIENT_ID)
                 .build();
+        assertEquals(expectedConfig, config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {-1L, Long.MIN_VALUE})
+    void GIVEN_too_small_ackTimeoutSeconds_provided_WHEN_bridge_config_created_THEN_min_ackTimeoutSeconds_used(long invalidAckTimeout) throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_ACK_TIMEOUT_SECONDS).dflt(invalidAckTimeout);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
+                .clientId(config.getClientId())
+                .ackTimeoutSeconds(DEFAULT_ACK_TIMEOUT_SECONDS)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {-1L, Long.MIN_VALUE})
+    void GIVEN_too_small_connAckTimeoutMs_provided_WHEN_bridge_config_created_THEN_min_connAckTimeoutMs_used(long invalidConnAckTimeout) throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_CONNACK_TIMEOUT_MS).dflt(invalidConnAckTimeout);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
+                .clientId(config.getClientId())
+                .connAckTimeoutMs(DEFAULT_CONNACK_TIMEOUT_MS)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {-1L, Long.MIN_VALUE})
+    void GIVEN_too_small_pingTimeoutMs_provided_WHEN_bridge_config_created_THEN_min_pingTimeoutMs_used(long invalidPingTimeout) throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_PING_TIMEOUT_MS).dflt(invalidPingTimeout);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
+                .clientId(config.getClientId())
+                .pingTimeoutMs(DEFAULT_PING_TIMEOUT_MS)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @Test
+    void GIVEN_maxReconnectDelay_less_than_minReconnectDelay_WHEN_bridge_config_created_THEN_exception_thrown() {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MAX_RECONNECT_DELAY_MS).dflt(10);
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MIN_RECONNECT_DELAY_MS).dflt(20);
+        assertThrows(InvalidConfigurationException.class, () -> BridgeConfig.fromTopics(topics));
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {-1L, Long.MIN_VALUE})
+    void GIVEN_too_small_maxReconnectDelayMs_provided_WHEN_bridge_config_created_THEN_min_maxReconnectDelayMs_used(long invalidMaxReconnectDelay) throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MAX_RECONNECT_DELAY_MS).dflt(invalidMaxReconnectDelay);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
+                .clientId(config.getClientId())
+                .maxReconnectDelayMs(DEFAULT_MAX_RECONNECT_DELAY_MS)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {-1L, Long.MIN_VALUE})
+    void GIVEN_too_small_minReconnectDelayMs_provided_WHEN_bridge_config_created_THEN_min_minReconnectDelayMs_used(long invalidMinReconnectDelay) throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MIN_RECONNECT_DELAY_MS).dflt(invalidMinReconnectDelay);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
+                .clientId(config.getClientId())
+                .minReconnectDelayMs(DEFAULT_MIN_RECONNECT_DELAY_MS)
+                .build();
+        assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
     }
 

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
@@ -107,6 +107,11 @@ class LocalMqtt5ClientTest {
         client.stop();
         client = new LocalMqtt5Client(URI.create("tcp://localhost"),
                 "test-client",
+                1L,
+                1L,
+                1L,
+                1L,
+                1L,
                 Collections.emptyMap(),
                 mock(MQTTClientKeyStore.class),
                 executorService);
@@ -444,6 +449,11 @@ class LocalMqtt5ClientTest {
         client = new LocalMqtt5Client(
                 URI.create("tcp://localhost:1883"),
                 "test-client",
+                1L,
+                1L,
+                1L,
+                1L,
+                1L,
                 opts,
                 mock(MQTTClientKeyStore.class),
                 executorService,


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds the following configuration properties:
* ackTimeoutSeconds
* connAckTimeoutMs
* pingTimeoutMs
* maxReconnectDelayMs
* minReconnectDelayMs

**Why is this change necessary:**
Customers can customize how long the local mqtt5 client waits for various operations

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
