### PR TITLE
chore: upgrade junit, mockito, and lombok

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>3.12.4</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.28</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -99,25 +99,25 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.6.2</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>3.2.4</version>
+            <version>3.12.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.6.2</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.6.2</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -415,6 +415,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <nucleus.version>2.10.0-SNAPSHOT</nucleus.version>
         <testcontainers.version>1.17.6</testcontainers.version>
+        <junit.version>5.9.2</junit.version>
         <skipTests>false</skipTests>
         <groups></groups>
         <mqttbridgejar.name>aws.greengrass.clientdevices.mqtt.Bridge</mqttbridgejar.name>

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestExtension.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestExtension.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.ConnectException;
 import java.net.URL;
+import java.nio.channels.ClosedChannelException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyStoreException;
@@ -154,6 +155,9 @@ public class BridgeIntegrationTestExtension implements AfterTestExecutionCallbac
         ignoreExceptionOfType(extensionContext, CrtRuntimeException.class);
         ignoreExceptionOfType(extensionContext, MqttException.class);
         ignoreExceptionUltimateCauseOfType(extensionContext, EOFException.class);
+
+        // when checking docker availability
+        ignoreExceptionOfType(extensionContext, ClosedChannelException.class);
 
         // relies on UniqueRootPathExtension being run before this extension via the IntegrationTest annotation
         context.setRootDir(Paths.get(System.getProperty("root")));

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStoreTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStoreTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -71,6 +72,7 @@ public class MQTTClientKeyStoreTest {
 
     @BeforeEach
     void beforeEach() throws NoSuchAlgorithmException {
+        assumeTrue(System.getProperty("java.version").startsWith("1.8"));
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
         kpg.initialize(2048);
         keyPair = kpg.generateKeyPair();

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStoreTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStoreTest.java
@@ -5,9 +5,11 @@
 
 package com.aws.greengrass.mqtt.bridge.auth;
 
-import com.aws.greengrass.clientdevices.auth.api.ClientDevicesAuthServiceApi;
 import com.aws.greengrass.clientdevices.auth.api.CertificateUpdateEvent;
+import com.aws.greengrass.clientdevices.auth.api.ClientDevicesAuthServiceApi;
 import com.aws.greengrass.clientdevices.auth.api.GetCertificateRequest;
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,64 +20,55 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocketFactory;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
-import java.security.KeyPairGenerator;
 import java.security.KeyStore;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
-import java.security.cert.CertificateEncodingException;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.Base64;
+import java.time.Instant;
 import java.util.Collections;
+import java.util.Date;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class MQTTClientKeyStoreTest {
-    private static final String CERTIFICATE = "-----BEGIN CERTIFICATE-----\r\n"
-            + "MIICujCCAaICCQCQcEEQmGoJqjANBgkqhkiG9w0BAQUFADAfMR0wGwYDVQQDDBRt\r\n"
-            + "b3F1ZXR0ZS5lY2xpcHNlLm9yZzAeFw0yMDA3MjExODA2MzdaFw0yMTA3MTYxODA2\r\n"
-            + "MzdaMB8xHTAbBgNVBAMMFG1vcXVldHRlLmVjbGlwc2Uub3JnMIIBIjANBgkqhkiG\r\n"
-            + "9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzA6+mCCxb4wcuMYo+U7n50MFfNiDoeXRdYgE\r\n"
-            + "JRSqk/1Op8K5IzeMGddRhQKi4f2nojRtHak7wCj1QzJrkQRs+N8FOIMT5h0qFOzP\r\n"
-            + "EJ4N39hGY+lnjsRl892zE52TzvPyvogChhth99U3KKf3d/bWjiX28edcY6/cxpKp\r\n"
-            + "UN7aY4eNkdsteeWGN3l99laxDzG+uWIntwtw0S2TgyPvYVDl/oDL80uFxXApP6R5\r\n"
-            + "/zBE3uGcHq+koqUP+dLiKJd5C+e2IojBxY8ACp3g47Memy66cyHBEm4OYRsejHsA\r\n"
-            + "jCqhQy8UMu7u+ldg61mNSgvbU9ex0RVCsoWYn/mHQrKBVfsTYwIDAQABMA0GCSqG\r\n"
-            + "SIb3DQEBBQUAA4IBAQCypHyuR3RHPUOC4bqzP//UY9RPgpwY9pw01+LCGdToTMeZ\r\n"
-            + "TyakWfmC8eT+TqmRtLHHNd5pVdSYQj9F9RrOGh5WgzvG+4s13OMwdzV11kTQxc3v\r\n"
-            + "r8HlEMLWbS9UIabezCBfUJfcZMr/9OY4N4S0n23Ed4hJ1xsfGnqb6bIw0JDAKZ8V\r\n"
-            + "e41Mh3o4lPB0MWM9Tuq701/ZPyEDTnFsZdEwlKQ04ZfIfo5xA26eIDJvrf3ZeYuz\r\n"
-            + "AgTh4Slc4H6sBg9OYPcvgVbrbO8gK1fl7B1YbtZsjut/8tYZ+OLkDkTXYS+AwFXl\r\n"
-            + "220FJlnogGSU9xvjdQCXzt6p+kC4cKpQBTqshgcA\r\n"
-            + "-----END CERTIFICATE-----\r\n";
-    private static final byte[] BEGIN_CERT = "-----BEGIN CERTIFICATE-----\r\n".getBytes(StandardCharsets.UTF_8);
-    private static final byte[] END_CERT = "\r\n-----END CERTIFICATE-----\r\n".getBytes(StandardCharsets.UTF_8);
+class MQTTClientKeyStoreTest {
+
+    String caCertPem;
+    X509Certificate caCert;
+    KeyPair caKeyPair;
+
+    X509Certificate clientCert;
+    KeyPair clientKeyPair;
 
     @Mock
-    private ClientDevicesAuthServiceApi mockServiceApi;
-    private KeyPair keyPair;
+    ClientDevicesAuthServiceApi mockServiceApi;
 
     @BeforeEach
-    void beforeEach() throws NoSuchAlgorithmException {
-        assumeTrue(System.getProperty("java.version").startsWith("1.8"));
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(2048);
-        keyPair = kpg.generateKeyPair();
+    void setUp() throws Exception {
+        caKeyPair = CertificateStore.newRSAKeyPair(2048);
+        caCert = CertificateHelper.createCACertificate(
+                caKeyPair,
+                Date.from(Instant.now()),
+                Date.from(Instant.now().plusSeconds(100)),
+                "CA"
+        );
+        caCertPem = CertificateHelper.toPem(caCert);
+
+        clientKeyPair = CertificateStore.newRSAKeyPair(2048);
+        clientCert = CertificateHelper.issueClientCertificate(
+                caCert,
+                caKeyPair.getPrivate(),
+                CertificateHelper.getX500Name("client"),
+                clientKeyPair.getPublic(),
+                Date.from(Instant.now()),
+                Date.from(Instant.now().plusSeconds(100)));
     }
 
     @Test
@@ -91,9 +84,8 @@ public class MQTTClientKeyStoreTest {
         KeyStore keyStore = mqttClientKeyStore.getKeyStore();
         assertThat(keyStore.size(), is(0));
 
-        X509Certificate certificate = pemToX509Certificate(CERTIFICATE);
         CertificateUpdateEvent certificateUpdate =
-                new CertificateUpdateEvent(keyPair, certificate, new X509Certificate[]{certificate});
+                new CertificateUpdateEvent(caKeyPair, clientCert, new X509Certificate[]{caCert});
         getCertificateRequest.getCertificateUpdateConsumer().accept(certificateUpdate);
         assertThat(keyStore.size(), is(1));
 
@@ -101,14 +93,8 @@ public class MQTTClientKeyStoreTest {
         assertThat(privateKey.getAlgorithm(), is("RSA"));
 
         assertThat(keyStore.getCertificateChain(MQTTClientKeyStore.KEY_ALIAS).length, is(2));
-        verifyStoredCertificate((X509Certificate) keyStore.getCertificateChain(MQTTClientKeyStore.KEY_ALIAS)[0]);
-        verifyStoredCertificate((X509Certificate) keyStore.getCertificateChain(MQTTClientKeyStore.KEY_ALIAS)[1]);
-    }
-
-    private void verifyStoredCertificate(X509Certificate cert) throws CertificateEncodingException, IOException {
-        byte[] certBytes = encodeToBase64Pem(cert.getEncoded(), BEGIN_CERT, END_CERT);
-        String certPem = new String(certBytes, StandardCharsets.UTF_8);
-        assertThat(certPem, is(CERTIFICATE));
+        assertEquals(clientCert, keyStore.getCertificateChain(MQTTClientKeyStore.KEY_ALIAS)[0]);
+        assertEquals(caCert, keyStore.getCertificateChain(MQTTClientKeyStore.KEY_ALIAS)[1]);
     }
 
     @Test
@@ -121,14 +107,11 @@ public class MQTTClientKeyStoreTest {
         KeyStore keyStore = mqttClientKeyStore.getKeyStore();
         assertThat(keyStore.size(), is(0));
 
-        mqttClientKeyStore.updateCA(Collections.singletonList(CERTIFICATE));
+        mqttClientKeyStore.updateCA(Collections.singletonList(caCertPem));
         assertThat(updateLatch.await(100, TimeUnit.MILLISECONDS), is(true));
         assertThat(keyStore.size(), is(1));
 
-        X509Certificate caCert = (X509Certificate) keyStore.getCertificate("CA0");
-        byte[] caCertBytes = encodeToBase64Pem(caCert.getEncoded(), BEGIN_CERT, END_CERT);
-        String caCertPem = new String(caCertBytes, StandardCharsets.UTF_8);
-        assertThat(caCertPem, is(CERTIFICATE));
+        assertEquals(caCert, keyStore.getCertificate("CA0"));
     }
 
     @Test
@@ -146,36 +129,14 @@ public class MQTTClientKeyStoreTest {
         KeyStore keyStore = mqttClientKeyStore.getKeyStore();
         assertThat(keyStore.size(), is(0));
 
-        X509Certificate certificate = pemToX509Certificate(CERTIFICATE);
         CertificateUpdateEvent certificateUpdate =
-                new CertificateUpdateEvent(keyPair, certificate, new X509Certificate[]{certificate});
+                new CertificateUpdateEvent(caKeyPair, clientCert, new X509Certificate[]{caCert});
         certificateRequest.getCertificateUpdateConsumer().accept(certificateUpdate);
-        mqttClientKeyStore.updateCA(Collections.singletonList(CERTIFICATE));
+        mqttClientKeyStore.updateCA(Collections.singletonList(caCertPem));
         assertThat(updateLatch.await(100, TimeUnit.MILLISECONDS), is(true));
         assertThat(keyStore.size(), is(2));
 
         SocketFactory socketFactory = mqttClientKeyStore.getSSLSocketFactory();
         assertThat(socketFactory, is(instanceOf(SSLSocketFactory.class)));
-    }
-
-    private byte[] encodeToBase64Pem(byte[] content, byte[] header, byte[] footer) throws IOException {
-        byte[] encodedBytes = Base64.getMimeEncoder(64, "\r\n".getBytes(StandardCharsets.UTF_8)).encode(content);
-        try (ByteArrayOutputStream contentStream = new ByteArrayOutputStream()) {
-            contentStream.write(header);
-            contentStream.write(encodedBytes);
-            contentStream.write(footer);
-            encodedBytes = contentStream.toByteArray();
-        }
-        return encodedBytes;
-    }
-
-    private X509Certificate pemToX509Certificate(String certPem) throws IOException, CertificateException {
-        byte[] certBytes = certPem.getBytes(StandardCharsets.UTF_8);
-        CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
-        X509Certificate cert;
-        try (InputStream certStream = new ByteArrayInputStream(certBytes)) {
-            cert = (X509Certificate) certFactory.generateCertificate(certStream);
-        }
-        return cert;
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Upgrade junit to latest, mockito to latest minor/patch, and lombok to latest

**Why is this change necessary:**
Not strictly necessary because we build with java 8, but was useful when I wanted to run profiling in IntelliJ, which required me to use a JDK > 1.8.

**How was this change tested:**
Ran unit and integ tests with jdk 8 and jdk 18

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
