### PR TITLE
feat: ability to stop broker in integ test

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestContext.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestContext.java
@@ -15,9 +15,13 @@ import com.aws.greengrass.mqtt.bridge.clients.MessageClient;
 import com.aws.greengrass.mqtt.bridge.clients.MockMqttClient;
 import com.aws.greengrass.mqtt.bridge.model.BridgeConfigReference;
 import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.Getter;
 
 import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 @Data
 public class BridgeIntegrationTestContext {
@@ -25,6 +29,10 @@ public class BridgeIntegrationTestContext {
     Integer brokerSSLPort;
     Integer brokerTCPPort;
     String brokerHost;
+    @Getter(AccessLevel.NONE)
+    Runnable stopBroker;
+    @Getter(AccessLevel.NONE)
+    Runnable startBroker;
     Path rootDir;
     Kernel kernel;
 
@@ -63,5 +71,19 @@ public class BridgeIntegrationTestContext {
             throw new RuntimeException("Kernel not available. Ensure the test method is annotated with @WithKernel");
         }
         return kernel.getContext().get(clazz);
+    }
+
+    public void startBroker() {
+        if (startBroker == null) {
+            fail("startBroker operation has not been set");
+        }
+        startBroker.run();
+    }
+
+    public void stopBroker() {
+        if (stopBroker == null) {
+            fail("stopBroker operation has not been set");
+        }
+        stopBroker.run();
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestExtensionTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestExtensionTest.java
@@ -10,8 +10,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.net.Socket;
+import java.util.function.Supplier;
+
+import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Disabled("Only useful to run when modifying classes in this package")
 @BridgeIntegrationTest
@@ -95,5 +102,24 @@ public class BridgeIntegrationTestExtensionTest {
         assertNotNull(context.getBrokerTCPPort());
         assertNull(context.getKernel());
         assertNotNull(context.getRootDir());
+    }
+
+    @TestWithAllBrokers
+    @WithKernel("config.yaml")
+    void GIVEN_any_broker_WHEN_test_restarts_broker_THEN_test_executes(Broker broker) {
+        Supplier<Boolean> brokerIsListening = () -> {
+            try (Socket ignored = new Socket("localhost", context.getBrokerTCPPort())) {
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        };
+        assertTrue(brokerIsListening.get());
+        context.stopBroker();
+        assertThat("broker stopped listening", brokerIsListening, eventuallyEval(is(false)));
+        assertThat("local client is disconnected", () -> context.getLocalV3Client().getMqttClientInternal().isConnected(), eventuallyEval(is(false)));
+        context.startBroker();
+        assertThat("broker is listening", brokerIsListening, eventuallyEval(is(true)));
+        assertThat("local client reconnects", () -> context.getLocalV3Client().getMqttClientInternal().isConnected(), eventuallyEval(is(true)));
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds functionality to `BridgeIntegrationTestContext` that lets integ tests stop and start the broker as desired.

**Why is this change necessary:**
To be used in https://github.com/aws-greengrass/aws-greengrass-mqtt-bridge/pull/136 to test how local mqtt client reacts to disconnects

**How was this change tested:**
new integration test that stops and starts the broker, verifying connectivity

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
