### PR TITLE
feat: configurable keep alive

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -116,7 +116,7 @@ public final class BridgeConfig {
 
         long keepAliveTimeoutSeconds = getKeepAliveTimeoutSeconds(configurationTopics);
         long pingTimeoutMs = getPingTimeoutMs(configurationTopics);
-        if (Duration.ofSeconds(keepAliveTimeoutSeconds).toMillis() <= pingTimeoutMs) {
+        if (keepAliveTimeoutSeconds != 0 && Duration.ofSeconds(keepAliveTimeoutSeconds).toMillis() <= pingTimeoutMs) {
             throw new InvalidConfigurationException(String.format("%s must be greater than %s",
                     KEY_KEEP_ALIVE_TIMEOUT_SECONDS, KEY_PING_TIMEOUT_MS));
         }

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -108,6 +108,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
     private final long ackTimeoutSeconds;
     private final long connAckTimeoutMs;
     private final long pingTimeoutMs;
+    private final long keepAliveTimeoutSeconds;
     private final long maxReconnectDelayMs;
     private final long minReconnectDelayMs;
 
@@ -241,19 +242,20 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
     /**
      * Construct a LocalMqtt5Client.
      *
-     * @param brokerUri             broker uri
-     * @param clientId              client id
-     * @param sessionExpiryInterval session expiry interval
-     * @param maximumPacketSize     maximum packet size
-     * @param receiveMaximum        receive maximum
-     * @param ackTimeoutSeconds   ack timeout seconds
-     * @param connAckTimeoutMs    connack timeout ms
-     * @param pingTimeoutMs       ping timeout ms
-     * @param maxReconnectDelayMs max reconnect delay ms
-     * @param minReconnectDelayMs min reconnect delay ms
-     * @param optionsByTopic      mqtt5 route options
-     * @param mqttClientKeyStore  KeyStore for MQTT Client
-     * @param executorService     Executor service
+     * @param brokerUri               broker uri
+     * @param clientId                client id
+     * @param sessionExpiryInterval   session expiry interval
+     * @param maximumPacketSize       maximum packet size
+     * @param receiveMaximum          receive maximum
+     * @param ackTimeoutSeconds       ack timeout seconds
+     * @param connAckTimeoutMs        connack timeout ms
+     * @param pingTimeoutMs           ping timeout ms
+     * @param keepAliveTimeoutSeconds keep alive timeout seconds
+     * @param maxReconnectDelayMs     max reconnect delay ms
+     * @param minReconnectDelayMs     min reconnect delay ms
+     * @param optionsByTopic          mqtt5 route options
+     * @param mqttClientKeyStore      KeyStore for MQTT Client
+     * @param executorService         Executor service
      * @throws MessageClientException if unable to create client for the mqtt broker
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")
@@ -265,6 +267,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
                             long ackTimeoutSeconds,
                             long connAckTimeoutMs,
                             long pingTimeoutMs,
+                            long keepAliveTimeoutSeconds,
                             long maxReconnectDelayMs,
                             long minReconnectDelayMs,
                             @NonNull Map<String, Mqtt5RouteOptions> optionsByTopic,
@@ -275,6 +278,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
         this.ackTimeoutSeconds = ackTimeoutSeconds;
         this.connAckTimeoutMs = connAckTimeoutMs;
         this.pingTimeoutMs = pingTimeoutMs;
+        this.keepAliveTimeoutSeconds = keepAliveTimeoutSeconds;
         this.maxReconnectDelayMs = maxReconnectDelayMs;
         this.minReconnectDelayMs = minReconnectDelayMs;
         this.mqttClientKeyStore = mqttClientKeyStore;
@@ -289,20 +293,21 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
     /**
      * Construct a LocalMqtt5Client for testing.
      *
-     * @param brokerUri             broker uri
-     * @param clientId              client id
-     * @param sessionExpiryInterval session expiry interval
-     * @param maximumPacketSize     maximum packet size
-     * @param receiveMaximum        receive maximum
-     * @param ackTimeoutSeconds   ack timeout seconds
-     * @param connAckTimeoutMs    connack timeout ms
-     * @param pingTimeoutMs       ping timeout ms
-     * @param maxReconnectDelayMs max reconnect delay ms
-     * @param minReconnectDelayMs min reconnect delay ms
-     * @param optionsByTopic      mqtt5 route options
-     * @param mqttClientKeyStore  mqttClientKeyStore
-     * @param executorService     Executor service
-     * @param client              mqtt client;
+     * @param brokerUri               broker uri
+     * @param clientId                client id
+     * @param sessionExpiryInterval   session expiry interval
+     * @param maximumPacketSize       maximum packet size
+     * @param receiveMaximum          receive maximum
+     * @param ackTimeoutSeconds       ack timeout seconds
+     * @param connAckTimeoutMs        connack timeout ms
+     * @param pingTimeoutMs           ping timeout ms
+     * @param keepAliveTimeoutSeconds keep alive timeout seconds
+     * @param maxReconnectDelayMs     max reconnect delay ms
+     * @param minReconnectDelayMs     min reconnect delay ms
+     * @param optionsByTopic          mqtt5 route options
+     * @param mqttClientKeyStore      mqttClientKeyStore
+     * @param executorService         Executor service
+     * @param client                  mqtt client;
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")
     LocalMqtt5Client(@NonNull URI brokerUri,
@@ -313,6 +318,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
                      long ackTimeoutSeconds,
                      long connAckTimeoutMs,
                      long pingTimeoutMs,
+                     long keepAliveTimeoutSeconds,
                      long maxReconnectDelayMs,
                      long minReconnectDelayMs,
                      @NonNull Map<String, Mqtt5RouteOptions> optionsByTopic,
@@ -324,6 +330,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
         this.ackTimeoutSeconds = ackTimeoutSeconds;
         this.connAckTimeoutMs = connAckTimeoutMs;
         this.pingTimeoutMs = pingTimeoutMs;
+        this.keepAliveTimeoutSeconds = keepAliveTimeoutSeconds;
         this.maxReconnectDelayMs = maxReconnectDelayMs;
         this.minReconnectDelayMs = minReconnectDelayMs;
         this.optionsByTopic = optionsByTopic;
@@ -624,6 +631,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
                     .withConnectOptions(new ConnectPacket.ConnectPacketBuilder()
                             .withRequestProblemInformation(true)
                             .withClientId(clientId)
+                            .withKeepAliveIntervalSeconds(keepAliveTimeoutSeconds)
                             .withSessionExpiryIntervalSeconds(sessionExpiryInterval)
                             .withMaximumPacketSizeBytes(maximumPacketSize)
                             .withReceiveMaximum((long) receiveMaximum)

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
@@ -59,6 +59,7 @@ public class LocalMqttClientFactory {
                         config.getAckTimeoutSeconds(),
                         config.getConnAckTimeoutMs(),
                         config.getPingTimeoutMs(),
+                        config.getKeepAliveTimeoutSeconds(),
                         config.getMaxReconnectDelayMs(),
                         config.getMinReconnectDelayMs(),
                         config.getMqtt5RouteOptionsForSource(TopicMapping.TopicType.LocalMqtt),

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -209,7 +209,7 @@ class BridgeConfigTest {
     }
 
     @Test
-    void GIVEN_ping_greater_than_zero_keepalive_WHEN_bridge_config_created_THEN_exception_thrown() throws InvalidConfigurationException {
+    void GIVEN_ping_greater_than_zero_keepalive_WHEN_bridge_config_created_THEN_ping_and_keepalive_used() throws InvalidConfigurationException {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_PING_TIMEOUT_MS).dflt(3000);
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_KEEP_ALIVE_TIMEOUT_SECONDS).dflt(0);
 

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -42,6 +42,7 @@ class BridgeConfigTest {
     private static final long DEFAULT_ACK_TIMEOUT_SECONDS = 60L;
     private static final long DEFAULT_CONNACK_TIMEOUT_MS = 20000L;
     private static final long DEFAULT_PING_TIMEOUT_MS = 30000L;
+    private static final long DEFAULT_KEEP_ALIVE_TIMEOUT_SECONDS = 60L;
     private static final long DEFAULT_MAX_RECONNECT_DELAY_MS = 30000L;
     private static final long DEFAULT_MIN_RECONNECT_DELAY_MS = 1000L;
     private static final String BROKER_URI = "tcp://localhost:8883";
@@ -60,6 +61,7 @@ class BridgeConfigTest {
             .ackTimeoutSeconds(DEFAULT_ACK_TIMEOUT_SECONDS)
             .connAckTimeoutMs(DEFAULT_CONNACK_TIMEOUT_MS)
             .pingTimeoutMs(DEFAULT_PING_TIMEOUT_MS)
+            .keepAliveTimeoutSeconds(DEFAULT_KEEP_ALIVE_TIMEOUT_SECONDS)
             .maxReconnectDelayMs(DEFAULT_MAX_RECONNECT_DELAY_MS)
             .minReconnectDelayMs(DEFAULT_MIN_RECONNECT_DELAY_MS)
             .build();
@@ -183,6 +185,27 @@ class BridgeConfigTest {
                 .build();
         assertDefaultClientId(config);
         assertEquals(expectedConfig, config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {-1L, Long.MIN_VALUE})
+    void GIVEN_too_small_keepAliveTimeoutMs_provided_WHEN_bridge_config_created_THEN_min_keepAliveTimeoutMs_used(long invalidKeepAliveTimeout) throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_KEEP_ALIVE_TIMEOUT_SECONDS).dflt(invalidKeepAliveTimeout);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
+                .clientId(config.getClientId())
+                .keepAliveTimeoutSeconds(DEFAULT_KEEP_ALIVE_TIMEOUT_SECONDS)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @Test
+    void GIVEN_ping_greater_than_keepalive_WHEN_bridge_config_created_THEN_exception_thrown() {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_PING_TIMEOUT_MS).dflt(3000);
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_KEEP_ALIVE_TIMEOUT_SECONDS).dflt(2);
+        assertThrows(InvalidConfigurationException.class, () -> BridgeConfig.fromTopics(topics));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -209,6 +209,21 @@ class BridgeConfigTest {
     }
 
     @Test
+    void GIVEN_ping_greater_than_zero_keepalive_WHEN_bridge_config_created_THEN_exception_thrown() throws InvalidConfigurationException {
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_PING_TIMEOUT_MS).dflt(3000);
+        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_KEEP_ALIVE_TIMEOUT_SECONDS).dflt(0);
+
+        BridgeConfig config = BridgeConfig.fromTopics(topics);
+        BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
+                .clientId(config.getClientId())
+                .pingTimeoutMs(3000)
+                .keepAliveTimeoutSeconds(0)
+                .build();
+        assertDefaultClientId(config);
+        assertEquals(expectedConfig, config);
+    }
+
+    @Test
     void GIVEN_maxReconnectDelay_less_than_minReconnectDelay_WHEN_bridge_config_created_THEN_exception_thrown() {
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MAX_RECONNECT_DELAY_MS).dflt(10);
         topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MIN_RECONNECT_DELAY_MS).dflt(20);

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
@@ -114,7 +114,7 @@ class LocalMqtt5ClientTest {
                 1L,
                 1L,
                 1L,
-                1L,
+                0L,
                 1L,
                 1L,
                 Collections.emptyMap(),

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
@@ -116,6 +116,7 @@ class LocalMqtt5ClientTest {
                 1L,
                 1L,
                 1L,
+                1L,
                 Collections.emptyMap(),
                 mock(MQTTClientKeyStore.class),
                 executorService);
@@ -456,6 +457,7 @@ class LocalMqtt5ClientTest {
                 BridgeConfig.DEFAULT_SESSION_EXPIRY_INTERVAL,
                 BridgeConfig.DEFAULT_MAXIMUM_PACKET_SIZE,
                 BridgeConfig.DEFAULT_RECEIVE_MAXIMUM,
+                1L,
                 1L,
                 1L,
                 1L,


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds `brokerClient/keepAliveTimeoutSeconds` configuration property, and ensures keep alive is greater than or equal to ping timeout.

**Why is this change necessary:**

**How was this change tested:**
Unit tests
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
