### PR TITLE
chore: rename brokerClient config to mqtt

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
@@ -107,13 +107,13 @@ public class ConfigTest {
         assertEquals(expectedMaximumPacketSize, testContext.getConfig().getMaximumPacketSize());
         assertEquals(expectedReceiveMaximum, testContext.getConfig().getReceiveMaximum());
 
-        // verify that the brokerClient config values are correctly set in the local client
+        // verify that the mqtt config values are correctly set in the local client
         assertEquals(expectedSessionExpiryInterval, testContext.getLocalV5Client().getSessionExpiryInterval());
         assertEquals(expectedMaximumPacketSize, testContext.getLocalV5Client().getMaximumPacketSize());
         assertEquals(expectedReceiveMaximum, testContext.getLocalV5Client().getReceiveMaximum());
 
         Topics config = testContext.getKernel().locate(MQTTBridge.SERVICE_NAME).getConfig()
-                .lookupTopics(CONFIGURATION_CONFIG_KEY).lookupTopics("brokerClient");
+                .lookupTopics(CONFIGURATION_CONFIG_KEY).lookupTopics("mqtt");
 
         // publish a small message and verify that it is received
         String topic = "topic/toLocal";

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_config_ssl.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_config_ssl.yaml
@@ -15,7 +15,7 @@ services:
           topic: topic/toLocal
           source: IotCore
           target: LocalMqtt
-      brokerClient:
+      mqtt:
         version: "mqtt5"
   main:
     dependencies:

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_connect_options.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_connect_options.yaml
@@ -7,7 +7,7 @@ services:
           topic: topic/toLocal
           source: LocalMqtt
           target: LocalMqtt
-      brokerClient:
+      mqtt:
         version: "mqtt5"
         receiveMaximum: 1000
         maximumPacketSize: 100

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_and_iotcore.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_and_iotcore.yaml
@@ -11,7 +11,7 @@ services:
           topic: topic/toLocal
           source: IotCore
           target: LocalMqtt
-      brokerClient:
+      mqtt:
         version: "mqtt5"
   main:
     dependencies:

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_to_iotcore_nolocal.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_to_iotcore_nolocal.yaml
@@ -10,7 +10,7 @@ services:
           topic: topic/toIotCore
           source: LocalMqtt
           target: IotCore
-      brokerClient:
+      mqtt:
         version: "mqtt5"
   main:
     dependencies:

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_to_iotcore_retain_as_published.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_to_iotcore_retain_as_published.yaml
@@ -10,7 +10,7 @@ services:
           topic: topic/toIotCore
           source: LocalMqtt
           target: IotCore
-      brokerClient:
+      mqtt:
         version: "mqtt5"
   main:
     dependencies:

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -57,7 +57,7 @@ public final class BridgeConfig {
     public static final String KEY_MAXIMUM_PACKET_SIZE = "maximumPacketSize";
     public static final String KEY_SESSION_EXPIRY_INTERVAL = "sessionExpiryInterval";
     public static final String KEY_MQTT_5_ROUTE_OPTIONS = "mqtt5RouteOptions";
-    static final String KEY_BROKER_CLIENT = "brokerClient";
+    static final String KEY_MQTT = "mqtt";
     static final String KEY_VERSION = "version";
 
 
@@ -158,7 +158,7 @@ public final class BridgeConfig {
 
     private static long getAckTimeoutSeconds(Topics configurationTopics) {
         long ackTimeoutSeconds = Coerce.toLong(configurationTopics.findOrDefault(DEFAULT_ACK_TIMEOUT_SECONDS,
-                KEY_BROKER_CLIENT, KEY_ACK_TIMEOUT_SECONDS));
+                KEY_MQTT, KEY_ACK_TIMEOUT_SECONDS));
         if (ackTimeoutSeconds < MIN_TIMEOUT) {
             LOGGER.atWarn().kv(KEY_ACK_TIMEOUT_SECONDS, ackTimeoutSeconds)
                     .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_ACK_TIMEOUT_SECONDS, DEFAULT_ACK_TIMEOUT_SECONDS);
@@ -169,7 +169,7 @@ public final class BridgeConfig {
 
     private static long getConnAckTimeoutMs(Topics configurationTopics) {
         long connackTimeoutSeconds = Coerce.toLong(configurationTopics.findOrDefault(DEFAULT_CONNACK_TIMEOUT_MS,
-                KEY_BROKER_CLIENT, KEY_CONNACK_TIMEOUT_MS));
+                KEY_MQTT, KEY_CONNACK_TIMEOUT_MS));
         if (connackTimeoutSeconds < MIN_TIMEOUT) {
             LOGGER.atWarn().kv(KEY_CONNACK_TIMEOUT_MS, connackTimeoutSeconds)
                     .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_CONNACK_TIMEOUT_MS, DEFAULT_CONNACK_TIMEOUT_MS);
@@ -180,7 +180,7 @@ public final class BridgeConfig {
 
     private static long getPingTimeoutMs(Topics configurationTopics) {
         long pingTimeoutMs = Coerce.toLong(configurationTopics.findOrDefault(DEFAULT_PING_TIMEOUT_MS,
-                KEY_BROKER_CLIENT, KEY_PING_TIMEOUT_MS));
+                KEY_MQTT, KEY_PING_TIMEOUT_MS));
         if (pingTimeoutMs < MIN_TIMEOUT) {
             LOGGER.atWarn().kv(KEY_PING_TIMEOUT_MS, pingTimeoutMs)
                     .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_PING_TIMEOUT_MS, DEFAULT_PING_TIMEOUT_MS);
@@ -191,7 +191,7 @@ public final class BridgeConfig {
 
     private static long getKeepAliveTimeoutSeconds(Topics configurationTopics) {
         long keepAliveTimeoutSeconds = Coerce.toLong(
-                configurationTopics.findOrDefault(DEFAULT_KEEP_ALIVE_TIMEOUT_SECONDS, KEY_BROKER_CLIENT,
+                configurationTopics.findOrDefault(DEFAULT_KEEP_ALIVE_TIMEOUT_SECONDS, KEY_MQTT,
                         KEY_KEEP_ALIVE_TIMEOUT_SECONDS));
         if (keepAliveTimeoutSeconds < MIN_TIMEOUT) {
             LOGGER.atWarn().kv(KEY_KEEP_ALIVE_TIMEOUT_SECONDS, keepAliveTimeoutSeconds)
@@ -204,7 +204,7 @@ public final class BridgeConfig {
 
     private static long getMaxReconnectDelayMs(Topics configurationTopics) {
         long maxReconnectDelayMs = Coerce.toLong(configurationTopics.findOrDefault(DEFAULT_MAX_RECONNECT_DELAY_MS,
-                KEY_BROKER_CLIENT, KEY_MAX_RECONNECT_DELAY_MS));
+                KEY_MQTT, KEY_MAX_RECONNECT_DELAY_MS));
         if (maxReconnectDelayMs < MIN_TIMEOUT) {
             LOGGER.atWarn().kv(KEY_MAX_RECONNECT_DELAY_MS, maxReconnectDelayMs)
                     .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_MAX_RECONNECT_DELAY_MS, DEFAULT_MAX_RECONNECT_DELAY_MS);
@@ -215,7 +215,7 @@ public final class BridgeConfig {
 
     private static long getMinReconnectDelayMs(Topics configurationTopics) {
         long minReconnectDelayMs = Coerce.toLong(configurationTopics.findOrDefault(DEFAULT_MIN_RECONNECT_DELAY_MS,
-                KEY_BROKER_CLIENT, KEY_MIN_RECONNECT_DELAY_MS));
+                KEY_MQTT, KEY_MIN_RECONNECT_DELAY_MS));
         if (minReconnectDelayMs < MIN_TIMEOUT) {
             LOGGER.atWarn().kv(KEY_MIN_RECONNECT_DELAY_MS, minReconnectDelayMs)
                     .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_MIN_RECONNECT_DELAY_MS, DEFAULT_MIN_RECONNECT_DELAY_MS);
@@ -251,13 +251,13 @@ public final class BridgeConfig {
     private static MqttVersion getMqttVersion(Topics configurationTopics) {
         return Coerce.toEnum(MqttVersion.class,
                 Coerce.toString(configurationTopics.findOrDefault(DEFAULT_MQTT_VERSION.name(),
-                        KEY_BROKER_CLIENT, KEY_VERSION)).toUpperCase(),
+                        KEY_MQTT, KEY_VERSION)).toUpperCase(),
                 DEFAULT_MQTT_VERSION);
     }
 
     private static int getReceiveMaximum(Topics configurationTopics) {
         int receiveMaximum = Coerce.toInt(configurationTopics.findOrDefault(DEFAULT_RECEIVE_MAXIMUM,
-                KEY_BROKER_CLIENT, KEY_RECEIVE_MAXIMUM));
+                KEY_MQTT, KEY_RECEIVE_MAXIMUM));
         if (receiveMaximum < MIN_RECEIVE_MAXIMUM) {
             LOGGER.atWarn().kv(KEY_RECEIVE_MAXIMUM, receiveMaximum)
                     .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_RECEIVE_MAXIMUM, MIN_RECEIVE_MAXIMUM);
@@ -273,7 +273,7 @@ public final class BridgeConfig {
 
     private static Long getMaximumPacketSize(Topics configurationTopics) {
         String maximumPacketSizeConf = Coerce.toString(configurationTopics.findOrDefault(DEFAULT_MAXIMUM_PACKET_SIZE,
-                KEY_BROKER_CLIENT, KEY_MAXIMUM_PACKET_SIZE));
+                KEY_MQTT, KEY_MAXIMUM_PACKET_SIZE));
         if (maximumPacketSizeConf == null) {
             return null;
         }
@@ -293,7 +293,7 @@ public final class BridgeConfig {
 
     private static long getSessionExpiryInterval(Topics configurationTopics) {
         long sessionExpiryInterval = Coerce.toLong(configurationTopics.findOrDefault(DEFAULT_SESSION_EXPIRY_INTERVAL,
-                KEY_BROKER_CLIENT, KEY_SESSION_EXPIRY_INTERVAL));
+                KEY_MQTT, KEY_SESSION_EXPIRY_INTERVAL));
         if (sessionExpiryInterval < MIN_SESSION_EXPIRY_INTERVAL) {
             LOGGER.atWarn().kv(KEY_SESSION_EXPIRY_INTERVAL, sessionExpiryInterval)
                     .log(INVALID_CONFIG_LOG_FORMAT_STRING, KEY_SESSION_EXPIRY_INTERVAL, MIN_SESSION_EXPIRY_INTERVAL);

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -148,7 +148,7 @@ class BridgeConfigTest {
     @ParameterizedTest
     @ValueSource(longs = {-1L, Long.MIN_VALUE})
     void GIVEN_too_small_ackTimeoutSeconds_provided_WHEN_bridge_config_created_THEN_min_ackTimeoutSeconds_used(long invalidAckTimeout) throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_ACK_TIMEOUT_SECONDS).dflt(invalidAckTimeout);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_ACK_TIMEOUT_SECONDS).dflt(invalidAckTimeout);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -162,7 +162,7 @@ class BridgeConfigTest {
     @ParameterizedTest
     @ValueSource(longs = {-1L, Long.MIN_VALUE})
     void GIVEN_too_small_connAckTimeoutMs_provided_WHEN_bridge_config_created_THEN_min_connAckTimeoutMs_used(long invalidConnAckTimeout) throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_CONNACK_TIMEOUT_MS).dflt(invalidConnAckTimeout);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_CONNACK_TIMEOUT_MS).dflt(invalidConnAckTimeout);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -176,7 +176,7 @@ class BridgeConfigTest {
     @ParameterizedTest
     @ValueSource(longs = {-1L, Long.MIN_VALUE})
     void GIVEN_too_small_pingTimeoutMs_provided_WHEN_bridge_config_created_THEN_min_pingTimeoutMs_used(long invalidPingTimeout) throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_PING_TIMEOUT_MS).dflt(invalidPingTimeout);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_PING_TIMEOUT_MS).dflt(invalidPingTimeout);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -190,7 +190,7 @@ class BridgeConfigTest {
     @ParameterizedTest
     @ValueSource(longs = {-1L, Long.MIN_VALUE})
     void GIVEN_too_small_keepAliveTimeoutMs_provided_WHEN_bridge_config_created_THEN_min_keepAliveTimeoutMs_used(long invalidKeepAliveTimeout) throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_KEEP_ALIVE_TIMEOUT_SECONDS).dflt(invalidKeepAliveTimeout);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_KEEP_ALIVE_TIMEOUT_SECONDS).dflt(invalidKeepAliveTimeout);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -203,15 +203,15 @@ class BridgeConfigTest {
 
     @Test
     void GIVEN_ping_greater_than_keepalive_WHEN_bridge_config_created_THEN_exception_thrown() {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_PING_TIMEOUT_MS).dflt(3000);
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_KEEP_ALIVE_TIMEOUT_SECONDS).dflt(2);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_PING_TIMEOUT_MS).dflt(3000);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_KEEP_ALIVE_TIMEOUT_SECONDS).dflt(2);
         assertThrows(InvalidConfigurationException.class, () -> BridgeConfig.fromTopics(topics));
     }
 
     @Test
     void GIVEN_ping_greater_than_zero_keepalive_WHEN_bridge_config_created_THEN_ping_and_keepalive_used() throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_PING_TIMEOUT_MS).dflt(3000);
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_KEEP_ALIVE_TIMEOUT_SECONDS).dflt(0);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_PING_TIMEOUT_MS).dflt(3000);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_KEEP_ALIVE_TIMEOUT_SECONDS).dflt(0);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -225,15 +225,15 @@ class BridgeConfigTest {
 
     @Test
     void GIVEN_maxReconnectDelay_less_than_minReconnectDelay_WHEN_bridge_config_created_THEN_exception_thrown() {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MAX_RECONNECT_DELAY_MS).dflt(10);
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MIN_RECONNECT_DELAY_MS).dflt(20);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_MAX_RECONNECT_DELAY_MS).dflt(10);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_MIN_RECONNECT_DELAY_MS).dflt(20);
         assertThrows(InvalidConfigurationException.class, () -> BridgeConfig.fromTopics(topics));
     }
 
     @ParameterizedTest
     @ValueSource(longs = {-1L, Long.MIN_VALUE})
     void GIVEN_too_small_maxReconnectDelayMs_provided_WHEN_bridge_config_created_THEN_min_maxReconnectDelayMs_used(long invalidMaxReconnectDelay) throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MAX_RECONNECT_DELAY_MS).dflt(invalidMaxReconnectDelay);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_MAX_RECONNECT_DELAY_MS).dflt(invalidMaxReconnectDelay);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -247,7 +247,7 @@ class BridgeConfigTest {
     @ParameterizedTest
     @ValueSource(longs = {-1L, Long.MIN_VALUE})
     void GIVEN_too_small_minReconnectDelayMs_provided_WHEN_bridge_config_created_THEN_min_minReconnectDelayMs_used(long invalidMinReconnectDelay) throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MIN_RECONNECT_DELAY_MS).dflt(invalidMinReconnectDelay);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_MIN_RECONNECT_DELAY_MS).dflt(invalidMinReconnectDelay);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -301,7 +301,7 @@ class BridgeConfigTest {
 
     @Test
     void GIVEN_mqtt_version_config_WHEN_bridge_config_created_THEN_version_set() throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_VERSION).dflt("mqtt5");
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_VERSION).dflt("mqtt5");
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -314,7 +314,7 @@ class BridgeConfigTest {
 
     @Test
     void GIVEN_invalid_mqtt_version_config_WHEN_bridge_config_created_THEN_default_version_used() throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_VERSION).dflt("INVALID_VALUE");
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_VERSION).dflt("INVALID_VALUE");
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
                 .clientId(config.getClientId())
@@ -326,7 +326,7 @@ class BridgeConfigTest {
     @ParameterizedTest
     @ValueSource(ints = {1, 1234, DEFAULT_RECEIVE_MAXIMUM})
     void GIVEN_receiveMaximum_provided_WHEN_bridge_config_created_THEN_receiveMaximum_used(int receiveMaximum) throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_RECEIVE_MAXIMUM).dflt(receiveMaximum);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_RECEIVE_MAXIMUM).dflt(receiveMaximum);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -340,7 +340,7 @@ class BridgeConfigTest {
     @ParameterizedTest
     @ValueSource(ints = {DEFAULT_RECEIVE_MAXIMUM + 1, Integer.MAX_VALUE})
     void GIVEN_too_large_receiveMaximum_provided_WHEN_bridge_config_created_THEN_max_receiveMaximum_used(int invalidReceiveMaximum) throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_RECEIVE_MAXIMUM).dflt(invalidReceiveMaximum);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_RECEIVE_MAXIMUM).dflt(invalidReceiveMaximum);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -354,7 +354,7 @@ class BridgeConfigTest {
     @ParameterizedTest
     @ValueSource(ints = {0, -1, Integer.MIN_VALUE})
     void GIVEN_too_small_receiveMaximum_provided_WHEN_bridge_config_created_THEN_min_receiveMaximum_used(int invalidReceiveMaximum) throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_RECEIVE_MAXIMUM).dflt(invalidReceiveMaximum);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_RECEIVE_MAXIMUM).dflt(invalidReceiveMaximum);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -368,7 +368,7 @@ class BridgeConfigTest {
     @ParameterizedTest
     @ValueSource(longs = {1, 1234, 4294967295L})
     void GIVEN_maximumPacketSize_provided_WHEN_bridge_config_created_THEN_maximumPacketSize_used(long maximumPacketSize) throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MAXIMUM_PACKET_SIZE).dflt(maximumPacketSize);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_MAXIMUM_PACKET_SIZE).dflt(maximumPacketSize);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -382,7 +382,7 @@ class BridgeConfigTest {
     @ParameterizedTest
     @ValueSource(longs = {0L, -1L, Long.MIN_VALUE})
     void GIVEN_too_small_maximumPacketSize_provided_WHEN_bridge_config_created_THEN_min_maximumPacketSize_used(long invalidMaximumPacketSize) throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MAXIMUM_PACKET_SIZE).dflt(invalidMaximumPacketSize);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_MAXIMUM_PACKET_SIZE).dflt(invalidMaximumPacketSize);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -396,7 +396,7 @@ class BridgeConfigTest {
     @ParameterizedTest
     @ValueSource(longs = {4294967296L, Long.MAX_VALUE})
     void GIVEN_too_large_maximumPacketSize_provided_WHEN_bridge_config_created_THEN_max_maximumPacketSize_used(long invalidMaximumPacketSize) throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_MAXIMUM_PACKET_SIZE).dflt(invalidMaximumPacketSize);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_MAXIMUM_PACKET_SIZE).dflt(invalidMaximumPacketSize);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -410,7 +410,7 @@ class BridgeConfigTest {
     @ParameterizedTest
     @ValueSource(longs = {0, 1234, 4294967295L})
     void GIVEN_sessionExpiryInterval_provided_WHEN_bridge_config_created_THEN_sessionExpiryInterval_used(long sessionExpiryInterval) throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_SESSION_EXPIRY_INTERVAL).dflt(sessionExpiryInterval);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_SESSION_EXPIRY_INTERVAL).dflt(sessionExpiryInterval);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -424,7 +424,7 @@ class BridgeConfigTest {
     @ParameterizedTest
     @ValueSource(longs = {-1L, Long.MIN_VALUE})
     void GIVEN_too_small_sessionExpiryInterval_provided_WHEN_bridge_config_created_THEN_min_sessionExpiryInterval_used(long invalidSessionExpiryInterval) throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_SESSION_EXPIRY_INTERVAL).dflt(invalidSessionExpiryInterval);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_SESSION_EXPIRY_INTERVAL).dflt(invalidSessionExpiryInterval);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -438,7 +438,7 @@ class BridgeConfigTest {
     @ParameterizedTest
     @ValueSource(longs = {4_294_967_296L, Long.MAX_VALUE})
     void GIVEN_too_large_sessionExpiryInterval_provided_WHEN_bridge_config_created_THEN_max_sessionExpiryInterval_used(long invalidSessionExpiryInterval) throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_SESSION_EXPIRY_INTERVAL).dflt(invalidSessionExpiryInterval);
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_SESSION_EXPIRY_INTERVAL).dflt(invalidSessionExpiryInterval);
 
         BridgeConfig config = BridgeConfig.fromTopics(topics);
         BridgeConfig expectedConfig = BASE_CONFIG.toBuilder()
@@ -472,7 +472,7 @@ class BridgeConfigTest {
 
     @Test
     void GIVEN_config_WHEN_get_route_options_for_source_THEN_options_returned() throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_VERSION).dflt("mqtt5");
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_VERSION).dflt("mqtt5");
 
         topics.lookupTopics(BridgeConfig.KEY_MQTT_TOPIC_MAPPING).replaceAndWait(
                 Utils.immutableMap(
@@ -502,7 +502,7 @@ class BridgeConfigTest {
 
     @Test
     void GIVEN_config_mqtt_3_WHEN_get_route_options_for_source_THEN_no_options_returned() throws InvalidConfigurationException {
-        topics.lookup(BridgeConfig.KEY_BROKER_CLIENT, BridgeConfig.KEY_VERSION).dflt("mqtt3");
+        topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_VERSION).dflt("mqtt3");
 
         topics.lookupTopics(BridgeConfig.KEY_MQTT_TOPIC_MAPPING).replaceAndWait(
                 Utils.immutableMap(


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
For consistency with spooler mqtt client, rename bridge's `brokerClient` configuration to `mqtt`.

**Why is this change necessary:**

**How was this change tested:**
unit and integration tests
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
