### PR TITLE
chore: adjust default receive maximum

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -72,7 +72,7 @@ public final class BridgeConfig {
     private static final String DEFAULT_BROKER_URI = "ssl://localhost:8883";
     private static final String DEFAULT_CLIENT_ID = "mqtt-bridge-" + Utils.generateRandomString(11);
     private static final MqttVersion DEFAULT_MQTT_VERSION = MqttVersion.MQTT3;
-    public static final int DEFAULT_RECEIVE_MAXIMUM = MAX_RECEIVE_MAXIMUM;
+    public static final int DEFAULT_RECEIVE_MAXIMUM = 100;
     public static final Long DEFAULT_MAXIMUM_PACKET_SIZE = null;
     public static final long DEFAULT_SESSION_EXPIRY_INTERVAL = MAX_SESSION_EXPIRY_INTERVAL;
     private static final long DEFAULT_ACK_TIMEOUT_SECONDS = 60L;

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -36,7 +36,7 @@ class BridgeConfigTest {
     private static final String DEFAULT_BROKER_URI = "ssl://localhost:8883";
     private static final String DEFAULT_CLIENT_ID_PREFIX = "mqtt-bridge-";
     private static final MqttVersion DEFAULT_MQTT_VERSION = MqttVersion.MQTT3;
-    private static final int DEFAULT_RECEIVE_MAXIMUM = 65535;
+    private static final int DEFAULT_RECEIVE_MAXIMUM = 100;
     private static final Long DEFAULT_MAXIMUM_PACKET_SIZE = null;
     private static final long DEFAULT_SESSION_EXPIRY_INTERVAL = 4_294_967_295L;
     private static final long DEFAULT_ACK_TIMEOUT_SECONDS = 60L;
@@ -338,7 +338,7 @@ class BridgeConfigTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {DEFAULT_RECEIVE_MAXIMUM + 1, Integer.MAX_VALUE})
+    @ValueSource(ints = {65536, Integer.MAX_VALUE})
     void GIVEN_too_large_receiveMaximum_provided_WHEN_bridge_config_created_THEN_max_receiveMaximum_used(int invalidReceiveMaximum) throws InvalidConfigurationException {
         topics.lookup(BridgeConfig.KEY_MQTT, BridgeConfig.KEY_RECEIVE_MAXIMUM).dflt(invalidReceiveMaximum);
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Lower the default receive maximum to `100`, matching spooler

**Why is this change necessary:**
Consistency with spooler, and using a more sane default value than 65535

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
