### PR TITLE
chore: default to mqtt5

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/config.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/config.yaml
@@ -5,6 +5,8 @@ services:
                 level: "DEBUG"
     aws.greengrass.clientdevices.mqtt.Bridge:
         configuration:
+            mqtt:
+                version: "mqtt3"
             brokerUri: 'tcp://localhost:8883'
     main:
         dependencies:

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/config_with_mapping.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/config_with_mapping.yaml
@@ -2,6 +2,8 @@ services:
   aws.greengrass.clientdevices.mqtt.Bridge:
     configuration:
       brokerUri: 'tcp://localhost:8883'
+      mqtt:
+        version: mqtt3
       mqtt5RouteOptions:
         mapping1:
           noLocal: true

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt3_local_and_iotcore.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt3_local_and_iotcore.yaml
@@ -2,6 +2,8 @@ services:
   aws.greengrass.clientdevices.mqtt.Bridge:
     configuration:
       brokerUri: 'tcp://localhost:8883'
+      mqtt:
+        version: mqtt3
       mqttTopicMapping:
         toIotCore:
           topic: topic/toIotCore

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_config_ssl.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_config_ssl.yaml
@@ -15,8 +15,6 @@ services:
           topic: topic/toLocal
           source: IotCore
           target: LocalMqtt
-      mqtt:
-        version: "mqtt5"
   main:
     dependencies:
       - aws.greengrass.clientdevices.mqtt.Bridge

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_connect_options.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_connect_options.yaml
@@ -8,7 +8,6 @@ services:
           source: LocalMqtt
           target: LocalMqtt
       mqtt:
-        version: "mqtt5"
         receiveMaximum: 1000
         maximumPacketSize: 100
         sessionExpiryInterval: 10

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_and_iotcore.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_and_iotcore.yaml
@@ -11,8 +11,6 @@ services:
           topic: topic/toLocal
           source: IotCore
           target: LocalMqtt
-      mqtt:
-        version: "mqtt5"
   main:
     dependencies:
       - aws.greengrass.clientdevices.mqtt.Bridge

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_to_iotcore_nolocal.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_to_iotcore_nolocal.yaml
@@ -10,8 +10,6 @@ services:
           topic: topic/toIotCore
           source: LocalMqtt
           target: IotCore
-      mqtt:
-        version: "mqtt5"
   main:
     dependencies:
       - aws.greengrass.clientdevices.mqtt.Bridge

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_to_iotcore_retain_as_published.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_to_iotcore_retain_as_published.yaml
@@ -10,8 +10,6 @@ services:
           topic: topic/toIotCore
           source: LocalMqtt
           target: IotCore
-      mqtt:
-        version: "mqtt5"
   main:
     dependencies:
       - aws.greengrass.clientdevices.mqtt.Bridge

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -71,7 +71,7 @@ public final class BridgeConfig {
 
     private static final String DEFAULT_BROKER_URI = "ssl://localhost:8883";
     private static final String DEFAULT_CLIENT_ID = "mqtt-bridge-" + Utils.generateRandomString(11);
-    private static final MqttVersion DEFAULT_MQTT_VERSION = MqttVersion.MQTT3;
+    private static final MqttVersion DEFAULT_MQTT_VERSION = MqttVersion.MQTT5;
     public static final int DEFAULT_RECEIVE_MAXIMUM = 100;
     public static final Long DEFAULT_MAXIMUM_PACKET_SIZE = null;
     public static final long DEFAULT_SESSION_EXPIRY_INTERVAL = MAX_SESSION_EXPIRY_INTERVAL;

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/BridgeConfigTest.java
@@ -35,7 +35,7 @@ class BridgeConfigTest {
 
     private static final String DEFAULT_BROKER_URI = "ssl://localhost:8883";
     private static final String DEFAULT_CLIENT_ID_PREFIX = "mqtt-bridge-";
-    private static final MqttVersion DEFAULT_MQTT_VERSION = MqttVersion.MQTT3;
+    private static final MqttVersion DEFAULT_MQTT_VERSION = MqttVersion.MQTT5;
     private static final int DEFAULT_RECEIVE_MAXIMUM = 100;
     private static final Long DEFAULT_MAXIMUM_PACKET_SIZE = null;
     private static final long DEFAULT_SESSION_EXPIRY_INTERVAL = 4_294_967_295L;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Set the default `mqtt/version` to `mqtt5` to match spooler.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
