### PR TITLE
fix(mqtt5) react to client certificate rotations

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
@@ -62,9 +62,8 @@ public class KeystoreTest {
     @WithKernel("mqtt5_config_ssl.yaml")
     void GIVEN_mqtt5_bridge_WHEN_client_cert_changes_THEN_memory_does_not_leak(Broker broker) throws Exception {
         while (true) {
-            CompletableFuture<Void> numConnects = asyncAssertNumConnects(1);
             testContext.getCerts().rotateClientCert();
-            numConnects.get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            Thread.sleep(5000L);
         }
     }
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
@@ -24,6 +24,7 @@ import com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore;
 import com.aws.greengrass.util.Pair;
 import lombok.Builder;
 import lombok.Setter;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import software.amazon.awssdk.crt.mqtt5.Mqtt5Client;
 import software.amazon.awssdk.crt.mqtt5.Mqtt5ClientOptions;
@@ -55,6 +56,17 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class KeystoreTest {
     private static final long AWAIT_TIMEOUT_SECONDS = 30L;
     BridgeIntegrationTestContext testContext;
+
+    @Disabled("use for manual memory leak testing")
+    @TestWithMqtt5Broker
+    @WithKernel("mqtt5_config_ssl.yaml")
+    void GIVEN_mqtt5_bridge_WHEN_client_cert_changes_THEN_memory_does_not_leak(Broker broker) throws Exception {
+        while (true) {
+            CompletableFuture<Void> numConnects = asyncAssertNumConnects(1);
+            testContext.getCerts().rotateClientCert();
+            numConnects.get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        }
+    }
 
     @TestWithMqtt5Broker
     @WithKernel("mqtt5_config_ssl.yaml")

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
@@ -22,7 +22,16 @@ import com.aws.greengrass.mqtt.bridge.BridgeConfig;
 import com.aws.greengrass.mqtt.bridge.MQTTBridge;
 import com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore;
 import com.aws.greengrass.util.Pair;
+import lombok.Builder;
+import lombok.Setter;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.crt.mqtt5.Mqtt5Client;
+import software.amazon.awssdk.crt.mqtt5.Mqtt5ClientOptions;
+import software.amazon.awssdk.crt.mqtt5.OnAttemptingConnectReturn;
+import software.amazon.awssdk.crt.mqtt5.OnConnectionFailureReturn;
+import software.amazon.awssdk.crt.mqtt5.OnConnectionSuccessReturn;
+import software.amazon.awssdk.crt.mqtt5.OnDisconnectionReturn;
+import software.amazon.awssdk.crt.mqtt5.OnStoppedReturn;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -31,6 +40,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.stream.IntStream;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
@@ -39,19 +49,56 @@ import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector
 import static com.aws.greengrass.testcommons.testutilities.TestUtils.asyncAssertOnConsumer;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @BridgeIntegrationTest
 public class KeystoreTest {
     private static final long AWAIT_TIMEOUT_SECONDS = 30L;
-
     BridgeIntegrationTestContext testContext;
+
+    @TestWithMqtt5Broker
+    @WithKernel("mqtt5_config_ssl.yaml")
+    void GIVEN_mqtt5_bridge_WHEN_client_cert_changes_THEN_local_client_restarts(Broker broker) throws Exception {
+        CompletableFuture<Void> numConnects = asyncAssertNumConnects(1);
+        testContext.getCerts().rotateClientCert();
+        testContext.getCerts().waitForBrokerToApplyStoreChanges();
+        numConnects.get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertTrue(testContext.getLocalV5Client().getClient().getIsConnected());
+    }
+
+    @TestWithMqtt5Broker
+    @WithKernel("mqtt5_config_ssl.yaml")
+    void GIVEN_mqtt5_bridge_WHEN_ca_changes_THEN_local_client_restarts(Broker broker) throws Exception {
+        CompletableFuture<Void> numConnects = asyncAssertNumConnects(1);
+        testContext.getCerts().rotateCA();
+        testContext.getCerts().rotateServerCert();
+        testContext.getCerts().rotateClientCert();
+        testContext.getCerts().waitForBrokerToApplyStoreChanges();
+        numConnects.get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertTrue(testContext.getLocalV5Client().getClient().getIsConnected());
+    }
+
+    @TestWithMqtt5Broker
+    @WithKernel("mqtt5_config_ssl.yaml")
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    void GIVEN_mqtt5_bridge_WHEN_client_cert_changes_a_lot_THEN_local_client_is_connected(Broker broker) throws Exception {
+        IntStream.range(0, 30).forEach(i -> {
+            try {
+                testContext.getCerts().rotateClientCert();
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+        testContext.getCerts().waitForBrokerToApplyStoreChanges();
+        assertTrue(testContext.getLocalV5Client().getClient().getIsConnected());
+    }
 
     @TestWithMqtt3Broker
     @WithKernel("config.yaml")
     void GIVEN_mqtt_bridge_WHEN_cda_ca_conf_changed_THEN_bridge_keystore_updated(Broker broker) throws Exception {
         Pair<CompletableFuture<Void>, Consumer<Void>> keystoreUpdated = asyncAssertOnConsumer(p -> {}, 1);
         MQTTClientKeyStore keyStore = testContext.getKernel().getContext().get(MQTTClientKeyStore.class);
-        keyStore.listenToCAUpdates(() -> keystoreUpdated.getRight().accept(null));
+        keyStore.listenToUpdates(() -> keystoreUpdated.getRight().accept(null));
 
         Topic certificateAuthoritiesTopic = testContext.getKernel().getConfig().lookup(
                 SERVICES_NAMESPACE_TOPIC,
@@ -110,7 +157,7 @@ public class KeystoreTest {
 
         CountDownLatch keyStoreUpdated = new CountDownLatch(1);
         MQTTClientKeyStore keyStore = testContext.getKernel().getContext().get(MQTTClientKeyStore.class);
-        keyStore.listenToCAUpdates(keyStoreUpdated::countDown);
+        keyStore.listenToUpdates(keyStoreUpdated::countDown);
 
         // update topic with CA
         Topic certificateAuthoritiesTopic = testContext.getKernel().getConfig().lookup(
@@ -130,5 +177,57 @@ public class KeystoreTest {
 
         // shouldn't update
         assertFalse(keyStoreUpdated.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    }
+
+    private CompletableFuture<Void> asyncAssertNumConnects(Integer numConnects) throws InterruptedException {
+        CountDownLatch callbackApplied = new CountDownLatch(1);
+        Pair<CompletableFuture<Void>, Consumer<Void>> onConnect
+                = asyncAssertOnConsumer(unused -> callbackApplied.countDown(),
+                numConnects + 1); // one call taken up by restarting for callback to take effect
+        testContext.getLocalV5Client().setConnectionEventCallback(
+                DelegatingConnectionEventsCallback.builder()
+                        .lifecycleEvents(testContext.getLocalV5Client().getConnectionEventCallback())
+                        .onConnectionSuccess(onConnect)
+                        .build());
+        // need to reset for new callback to take effect
+        testContext.getLocalV5Client().reset();
+        assertTrue(callbackApplied.await(5L, TimeUnit.SECONDS));
+        return onConnect.getLeft();
+    }
+
+    @Builder
+    static class DelegatingConnectionEventsCallback implements Mqtt5ClientOptions.LifecycleEvents {
+
+        private final Mqtt5ClientOptions.LifecycleEvents lifecycleEvents;
+        @Setter
+        private Pair<CompletableFuture<Void>, Consumer<Void>> onConnectionSuccess;
+
+        @Override
+        public void onAttemptingConnect(Mqtt5Client mqtt5Client, OnAttemptingConnectReturn onAttemptingConnectReturn) {
+            lifecycleEvents.onAttemptingConnect(mqtt5Client, onAttemptingConnectReturn);
+        }
+
+        @Override
+        public void onConnectionSuccess(Mqtt5Client mqtt5Client, OnConnectionSuccessReturn onConnectionSuccessReturn) {
+            if (onConnectionSuccess != null) {
+                onConnectionSuccess.getRight().accept(null);
+            }
+            lifecycleEvents.onConnectionSuccess(mqtt5Client, onConnectionSuccessReturn);
+        }
+
+        @Override
+        public void onConnectionFailure(Mqtt5Client mqtt5Client, OnConnectionFailureReturn onConnectionFailureReturn) {
+            lifecycleEvents.onConnectionFailure(mqtt5Client, onConnectionFailureReturn);
+        }
+
+        @Override
+        public void onDisconnection(Mqtt5Client mqtt5Client, OnDisconnectionReturn onDisconnectionReturn) {
+            lifecycleEvents.onDisconnection(mqtt5Client, onDisconnectionReturn);
+        }
+
+        @Override
+        public void onStopped(Mqtt5Client mqtt5Client, OnStoppedReturn onStoppedReturn) {
+            lifecycleEvents.onStopped(mqtt5Client, onStoppedReturn);
+        }
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestContext.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestContext.java
@@ -35,6 +35,7 @@ public class BridgeIntegrationTestContext {
     Runnable startBroker;
     Path rootDir;
     Kernel kernel;
+    Certs certs;
 
     public MockMqttClient getMockMqttClient() {
         return getFromContext(MockMqttClient.class);

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -136,7 +136,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
     private final ScheduledExecutorService ses;
     private final Map<String, Mqtt5RouteOptions> optionsByTopic;
 
-    private static final Duration DEFAULT_RESET_DELAY = Duration.ofSeconds(1);
+    private static final Duration DEFAULT_RESET_DELAY = Duration.ofMillis(100);
     private static final Duration MAX_RESET_DELAY = Duration.ofMinutes(5);
     private final Object resetLock = new Object();
     private Duration resetDelay = DEFAULT_RESET_DELAY;
@@ -744,7 +744,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
     private void scheduleResetTask() {
         synchronized (resetLock) {
             cancelResetTask();
-            resetTask = ses.schedule(this::reset, resetDelay.getSeconds(), TimeUnit.SECONDS);
+            resetTask = ses.schedule(this::reset, resetDelay.toMillis(), TimeUnit.MILLISECONDS);
             resetDelay = resetDelay.plus(resetDelay); // exponential backoff
             if (resetDelay.compareTo(MAX_RESET_DELAY) > 0) {
                 resetDelay = MAX_RESET_DELAY;

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -751,7 +751,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
     public void reset() {
         synchronized (resetLock) {
             LOGGER.atWarn().log("Beginning client reset. The client will be offline for a period of time,"
-                    + "during which messages will dropped.");
+                    + "during which messages will dropped");
 
             closeClient();
 

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -750,7 +750,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
      */
     public void reset() {
         synchronized (resetLock) {
-            LOGGER.atWarn().log("Beginning client reset. The client will be offline for a period of time,"
+            LOGGER.atWarn().log("Beginning client reset. The client will be offline for a period of time, "
                     + "during which messages will dropped");
 
             closeClient();

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -734,6 +734,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
                 LOGGER.atWarn().cause(e).log("Unable to start mqtt client, will retry");
                 closeClient();
                 scheduleResetTask();
+                return;
             }
 
             // started successfully, reset the reset delay

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -368,7 +368,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
     public void publish(MqttMessage message) throws MessageClientException {
         Mqtt5Client client = this.client;
         if (clientNotConnected(client)) {
-            LOGGER.atDebug()
+            LOGGER.atTrace()
                     .kv(LOG_KEY_MESSAGE, message)
                     .log("Skipping publish, client not connected. "
                             + "Publish will NOT be retried");

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.mqtt.bridge.model.BridgeConfigReference;
 import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
 
 public class LocalMqttClientFactory {
@@ -20,6 +21,7 @@ public class LocalMqttClientFactory {
     private final BridgeConfigReference config;
     private final MQTTClientKeyStore mqttClientKeyStore;
     private final ExecutorService executorService;
+    private final ScheduledExecutorService ses;
 
     /**
      * Create a new LocalMqttClientFactory.
@@ -27,14 +29,17 @@ public class LocalMqttClientFactory {
      * @param config             bridge config
      * @param mqttClientKeyStore mqtt client key store
      * @param executorService    executor service
+     * @param ses                scheduled executor service
      */
     @Inject
     public LocalMqttClientFactory(BridgeConfigReference config,
                                   MQTTClientKeyStore mqttClientKeyStore,
-                                  ExecutorService executorService) {
+                                  ExecutorService executorService,
+                                  ScheduledExecutorService ses) {
         this.config = config;
         this.mqttClientKeyStore = mqttClientKeyStore;
         this.executorService = executorService;
+        this.ses = ses;
     }
 
     /**
@@ -64,7 +69,8 @@ public class LocalMqttClientFactory {
                         config.getMinReconnectDelayMs(),
                         config.getMqtt5RouteOptionsForSource(TopicMapping.TopicType.LocalMqtt),
                         mqttClientKeyStore,
-                        executorService
+                        executorService,
+                        ses
                 );
             case MQTT3: // fall-through
             default:

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
@@ -248,7 +248,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
 
     static class FakeMqttClientFactory extends LocalMqttClientFactory {
         public FakeMqttClientFactory() {
-            super(null, null, null);
+            super(null, null, null, null);
         }
 
         @Override

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStoreTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/auth/MQTTClientKeyStoreTest.java
@@ -102,7 +102,7 @@ class MQTTClientKeyStoreTest {
         MQTTClientKeyStore mqttClientKeyStore = new MQTTClientKeyStore(mockServiceApi);
         mqttClientKeyStore.init();
         CountDownLatch updateLatch = new CountDownLatch(1);
-        mqttClientKeyStore.listenToCAUpdates(updateLatch::countDown);
+        mqttClientKeyStore.listenToUpdates(updateLatch::countDown);
 
         KeyStore keyStore = mqttClientKeyStore.getKeyStore();
         assertThat(keyStore.size(), is(0));
@@ -119,7 +119,7 @@ class MQTTClientKeyStoreTest {
         MQTTClientKeyStore mqttClientKeyStore = new MQTTClientKeyStore(mockServiceApi);
         mqttClientKeyStore.init();
         CountDownLatch updateLatch = new CountDownLatch(1);
-        mqttClientKeyStore.listenToCAUpdates(updateLatch::countDown);
+        mqttClientKeyStore.listenToUpdates(updateLatch::countDown);
 
         ArgumentCaptor<GetCertificateRequest> cbArgumentCaptor = ArgumentCaptor.forClass(GetCertificateRequest.class);
         verify(mockServiceApi, times(1))

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
@@ -119,7 +119,8 @@ class LocalMqtt5ClientTest {
                 1L,
                 Collections.emptyMap(),
                 mock(MQTTClientKeyStore.class),
-                executorService);
+                executorService,
+                null);
     }
 
     @Test
@@ -466,6 +467,7 @@ class LocalMqtt5ClientTest {
                 opts,
                 mock(MQTTClientKeyStore.class),
                 executorService,
+                null,
                 null
         );
 

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
@@ -88,8 +88,8 @@ class LocalMqtt5ClientTest {
         ignoreExceptionOfType(context, CrtRuntimeException.class);
         mockMqtt5Client.failToStart(2);
         client.reset();
-        assertThat("client disconnects", () -> client.getClient().getIsConnected(), eventuallyEval(is(false)));
-        assertThat("client reconnects", () -> client.getClient().getIsConnected(), eventuallyEval(is(true)));
+        assertThat("client disconnects", () -> client.client.getIsConnected(), eventuallyEval(is(false)));
+        assertThat("client reconnects", () -> client.client.getIsConnected(), eventuallyEval(is(true)));
     }
 
     @Test
@@ -104,8 +104,8 @@ class LocalMqtt5ClientTest {
             return mockMqtt5Client.getClient();
         });
         client.reset();
-        assertThat("client disconnects", () -> client.getClient().getIsConnected(), eventuallyEval(is(false)));
-        assertThat("client reconnects", () -> client.getClient().getIsConnected(), eventuallyEval(is(true)));
+        assertThat("client disconnects", () -> client.client.getIsConnected(), eventuallyEval(is(false)));
+        assertThat("client reconnects", () -> client.client.getIsConnected(), eventuallyEval(is(true)));
     }
 
     @Test
@@ -535,6 +535,6 @@ class LocalMqtt5ClientTest {
                 client.getPublishEventsCallback()
         );
         client.setClientSupplier(mockMqtt5Client::getClient);
-        client.setClient(mockMqtt5Client.getClient());
+        client.client = mockMqtt5Client.getClient();
     }
 }

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClientTest.java
@@ -86,7 +86,7 @@ public class MQTTClientTest {
 
         mqttClient.stop();
 
-        verify(mockMqttClientKeyStore).unsubscribeFromCAUpdates(any());
+        verify(mockMqttClientKeyStore).unsubscribeFromUpdates(any());
         subscriptions = fakeMqttClient.getSubscriptionTopics();
         assertThat(fakeMqttClient.isConnected(), is(false));
         assertThat(subscriptions, hasSize(0));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Reset `LocalMqtt5Client` after CDA generates a client certificates so that it may used in the MQTT connection.

**Why is this change necessary:**
Client certificates rotate weekly by default and bridge mqtt5 client needs a way to use the new certificates.

**How was this change tested:**
##### Integration tests:
* rotate client cert and verify that local client resets
* rotate ca cert, server cert, and client cert, and verify local client resets
* rotate client certs in rapid succession, to test concurrency
##### Unit tests:
* verify that resets will be retried on failure
##### Memory:
Rotated client certs in a loop for 40 minutes, memory looks pretty stable
![image](https://github.com/aws-greengrass/aws-greengrass-mqtt-bridge/assets/3164977/7a28132b-7f25-4544-be5c-f08f8e09c862)


Both integration tests use certificates that are used by both broker (HiveMQ) and client.  the broker will dynamically reload on server certs and trust store changes.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
