### PR TITLE
feat: handle unrecoverable errors

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -61,6 +61,7 @@ public class MQTTBridge extends PluginService {
     private final IoTCoreClient ioTCoreClient;
     @Getter // for tests
     private final BridgeConfigReference bridgeConfig;
+    private final FatalErrorHandler fatalErrorHandler;
 
 
     /**
@@ -89,8 +90,8 @@ public class MQTTBridge extends PluginService {
                       BridgeConfigReference bridgeConfig,
                       FatalErrorHandler fatalErrorHandler) {
         this(topics, topicMapping, new MessageBridge(topicMapping, Collections.emptyMap()), pubSubIPCAgent,
-                iotMqttClient, kernel, mqttClientKeyStore, localMqttClientFactory, executorService, bridgeConfig);
-        fatalErrorHandler.initialize(this::serviceErrored);
+                iotMqttClient, kernel, mqttClientKeyStore, localMqttClientFactory, executorService, bridgeConfig,
+                fatalErrorHandler);
     }
 
     // for testing
@@ -104,7 +105,8 @@ public class MQTTBridge extends PluginService {
                          MQTTClientKeyStore mqttClientKeyStore,
                          LocalMqttClientFactory localMqttClientFactory,
                          ExecutorService executorService,
-                         BridgeConfigReference bridgeConfig) {
+                         BridgeConfigReference bridgeConfig,
+                         FatalErrorHandler fatalErrorHandler) {
         super(topics);
         this.topicMapping = topicMapping;
         this.kernel = kernel;
@@ -116,6 +118,7 @@ public class MQTTBridge extends PluginService {
         this.configurationChangeHandler = new ConfigurationChangeHandler();
         this.certificateAuthorityChangeHandler = new CertificateAuthorityChangeHandler();
         this.bridgeConfig = bridgeConfig;
+        this.fatalErrorHandler = fatalErrorHandler;
     }
 
     @Override
@@ -127,6 +130,8 @@ public class MQTTBridge extends PluginService {
 
     @Override
     public void startup() {
+        fatalErrorHandler.initialize(this::serviceErrored);
+
         try {
             mqttClientKeyStore.init();
         } catch (KeyStoreException | CertificateGenerationException e) {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore;
 import com.aws.greengrass.mqtt.bridge.clients.IoTCoreClient;
+import com.aws.greengrass.mqtt.bridge.clients.LocalMqtt5Client;
 import com.aws.greengrass.mqtt.bridge.clients.LocalMqttClientFactory;
 import com.aws.greengrass.mqtt.bridge.clients.MessageClient;
 import com.aws.greengrass.mqtt.bridge.clients.MessageClientException;
@@ -25,6 +26,7 @@ import com.aws.greengrass.mqtt.bridge.clients.PubSubClient;
 import com.aws.greengrass.mqtt.bridge.model.BridgeConfigReference;
 import com.aws.greengrass.mqtt.bridge.model.InvalidConfigurationException;
 import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
+import com.aws.greengrass.mqtt.bridge.util.FatalErrorHandler;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.util.BatchedSubscriber;
 import lombok.Getter;
@@ -73,21 +75,32 @@ public class MQTTBridge extends PluginService {
      * @param localMqttClientFactory local mqtt client factory
      * @param executorService        Executor service
      * @param bridgeConfig           reference to bridge config
+     * @param fatalErrorHandler      fatal error handler
      */
     @Inject
-    public MQTTBridge(Topics topics, TopicMapping topicMapping, PubSubIPCEventStreamAgent pubSubIPCAgent,
-                      MqttClient iotMqttClient, Kernel kernel, MQTTClientKeyStore mqttClientKeyStore,
+    public MQTTBridge(Topics topics,
+                      TopicMapping topicMapping,
+                      PubSubIPCEventStreamAgent pubSubIPCAgent,
+                      MqttClient iotMqttClient,
+                      Kernel kernel,
+                      MQTTClientKeyStore mqttClientKeyStore,
                       LocalMqttClientFactory localMqttClientFactory,
                       ExecutorService executorService,
-                      BridgeConfigReference bridgeConfig) {
+                      BridgeConfigReference bridgeConfig,
+                      FatalErrorHandler fatalErrorHandler) {
         this(topics, topicMapping, new MessageBridge(topicMapping, Collections.emptyMap()), pubSubIPCAgent,
                 iotMqttClient, kernel, mqttClientKeyStore, localMqttClientFactory, executorService, bridgeConfig);
+        fatalErrorHandler.initialize(this::serviceErrored);
     }
 
     // for testing
     @SuppressWarnings("PMD.ExcessiveParameterList")
-    protected MQTTBridge(Topics topics, TopicMapping topicMapping, MessageBridge messageBridge,
-                         PubSubIPCEventStreamAgent pubSubIPCAgent, MqttClient iotMqttClient, Kernel kernel,
+    protected MQTTBridge(Topics topics,
+                         TopicMapping topicMapping,
+                         MessageBridge messageBridge,
+                         PubSubIPCEventStreamAgent pubSubIPCAgent,
+                         MqttClient iotMqttClient,
+                         Kernel kernel,
                          MQTTClientKeyStore mqttClientKeyStore,
                          LocalMqttClientFactory localMqttClientFactory,
                          ExecutorService executorService,

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -736,11 +736,11 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
      * Stop and start the client.
      */
     public void reset() {
-        if (fatalErrorHandler.fatalErrorOccurred()) {
-            LOGGER.atWarn().log("Skipping client reset due to recent fatal error");
-            return;
-        }
         synchronized (restartLock) {
+            if (fatalErrorHandler.fatalErrorOccurred()) {
+                LOGGER.atWarn().log("Skipping client reset due to recent fatal error");
+                return;
+            }
             long stopTimeoutSeconds = 10L;
             Future<?> previousRestartTask = restartTask;
             restartTask = executorService.submit(() -> {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.mqtt.bridge.TopicMapping;
 import com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore;
 import com.aws.greengrass.mqtt.bridge.model.BridgeConfigReference;
 import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
+import com.aws.greengrass.mqtt.bridge.util.FatalErrorHandler;
 
 import java.util.concurrent.ExecutorService;
 import javax.inject.Inject;
@@ -20,6 +21,7 @@ public class LocalMqttClientFactory {
     private final BridgeConfigReference config;
     private final MQTTClientKeyStore mqttClientKeyStore;
     private final ExecutorService executorService;
+    private final FatalErrorHandler fatalErrorHandler;
 
     /**
      * Create a new LocalMqttClientFactory.
@@ -27,14 +29,17 @@ public class LocalMqttClientFactory {
      * @param config             bridge config
      * @param mqttClientKeyStore mqtt client key store
      * @param executorService    executor service
+     * @param fatalErrorHandler  fatal error handler
      */
     @Inject
     public LocalMqttClientFactory(BridgeConfigReference config,
                                   MQTTClientKeyStore mqttClientKeyStore,
-                                  ExecutorService executorService) {
+                                  ExecutorService executorService,
+                                  FatalErrorHandler fatalErrorHandler) {
         this.config = config;
         this.mqttClientKeyStore = mqttClientKeyStore;
         this.executorService = executorService;
+        this.fatalErrorHandler = fatalErrorHandler;
     }
 
     /**
@@ -64,7 +69,8 @@ public class LocalMqttClientFactory {
                         config.getMinReconnectDelayMs(),
                         config.getMqtt5RouteOptionsForSource(TopicMapping.TopicType.LocalMqtt),
                         mqttClientKeyStore,
-                        executorService
+                        executorService,
+                        fatalErrorHandler
                 );
             case MQTT3: // fall-through
             default:

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/util/FatalErrorHandler.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/util/FatalErrorHandler.java
@@ -14,6 +14,7 @@ public class FatalErrorHandler {
     private Consumer<Exception> callback;
 
     public void initialize(Consumer<Exception> callback) {
+        this.fatalClientError.set(null);
         this.callback = callback;
     }
 

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/util/FatalErrorHandler.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/util/FatalErrorHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.mqtt.bridge.util;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+public class FatalErrorHandler {
+
+    public final AtomicReference<Exception> fatalClientError = new AtomicReference<>();
+    private Consumer<Exception> callback;
+
+    public void initialize(Consumer<Exception> callback) {
+        this.callback = callback;
+    }
+
+    public boolean fatalErrorOccurred() {
+        return fatalClientError.get() != null;
+    }
+
+    public void fatalError(Exception e) {
+        fatalClientError.set(e);
+        if (callback != null) {
+            callback.accept(e);
+        }
+    }
+}

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/MQTTBridgeTest.java
@@ -248,7 +248,7 @@ public class MQTTBridgeTest extends GGServiceTestUtil {
 
     static class FakeMqttClientFactory extends LocalMqttClientFactory {
         public FakeMqttClientFactory() {
-            super(null, null, null);
+            super(null, null, null, null);
         }
 
         @Override

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
@@ -9,6 +9,7 @@ import com.aws.greengrass.mqtt.bridge.BridgeConfig;
 import com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore;
 import com.aws.greengrass.mqtt.bridge.model.Mqtt5RouteOptions;
 import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
+import com.aws.greengrass.mqtt.bridge.util.FatalErrorHandler;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -119,7 +120,8 @@ class LocalMqtt5ClientTest {
                 1L,
                 Collections.emptyMap(),
                 mock(MQTTClientKeyStore.class),
-                executorService);
+                executorService,
+                mock(FatalErrorHandler.class));
     }
 
     @Test
@@ -466,7 +468,8 @@ class LocalMqtt5ClientTest {
                 opts,
                 mock(MQTTClientKeyStore.class),
                 executorService,
-                null
+                null,
+                mock(FatalErrorHandler.class)
         );
 
         lifecycleEvents = spy(new Mqtt5ClientOptions.LifecycleEvents() {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
If an unrecoverable error happens in bridge's mqtt5 client, bubble the error up to the component level

**Why is this change necessary:**
In bridge's mqtt5 client, if we perform a reset, due to client certs or CA certs rotating, there's a chance that creating the new CRT client will fail.  However, I'm unsure of the exact failure mode.  Presumably the only thing in greengrass' control is the certs it configures the CRT client with, that are taken from CDA.  This would fail if certs provided by CDA are malformed, which in theory would never happen.  So if CRT client creation throws an exception, we can either 1) retry (likely wasteful), or 2) log and do nothing (bad), 3) error bridge.  My thinking is that it would be worth erroring the component so that the customer can be notified and fix the issue, since it doesn't appear that recovery within bridge would happen.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
