### PR TITLE
refactor: always subscribe to keystore updates

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -95,14 +95,24 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
     private final MQTTClientKeyStore.UpdateListener onKeyStoreUpdate = new MQTTClientKeyStore.UpdateListener() {
         @Override
         public void onCAUpdate() {
+            if (ignoreUpdate()) {
+                return;
+            }
             LOGGER.atInfo().log("New CA cert available, reconnecting client");
             scheduleResetTask();
         }
 
         @Override
         public void onClientCertUpdate() {
+            if (ignoreUpdate()) {
+                return;
+            }
             LOGGER.atInfo().log("New client certificate available, reconnecting client");
             scheduleResetTask();
+        }
+
+        private boolean ignoreUpdate() {
+            return !isSSL();
         }
     };
 
@@ -631,9 +641,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
 
     @Override
     public void start()  {
-        if (isSSL()) {
-            mqttClientKeyStore.listenToUpdates(onKeyStoreUpdate);
-        }
+        mqttClientKeyStore.listenToUpdates(onKeyStoreUpdate);
         client.start();
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Refactor mqtt5 client so that it always subscribes to keystore updates on start and then filters events.

**Why is this change necessary:**
Eventually mqtt5 client will reset on configuration changes.  With this change, we don't need to worry about subscribing/unsubscribing to keystore when brokerUri changes, which opens the possibility of missing events.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
