### PR TITLE
refactor: client config as builder

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ConfigTest.java
@@ -108,9 +108,9 @@ public class ConfigTest {
         assertEquals(expectedReceiveMaximum, testContext.getConfig().getReceiveMaximum());
 
         // verify that the mqtt config values are correctly set in the local client
-        assertEquals(expectedSessionExpiryInterval, testContext.getLocalV5Client().getSessionExpiryInterval());
-        assertEquals(expectedMaximumPacketSize, testContext.getLocalV5Client().getMaximumPacketSize());
-        assertEquals(expectedReceiveMaximum, testContext.getLocalV5Client().getReceiveMaximum());
+        assertEquals(expectedSessionExpiryInterval, testContext.getLocalV5Client().getConfig().getSessionExpiryInterval());
+        assertEquals(expectedMaximumPacketSize, testContext.getLocalV5Client().getConfig().getMaximumPacketSize());
+        assertEquals(expectedReceiveMaximum, testContext.getLocalV5Client().getConfig().getReceiveMaximum());
 
         Topics config = testContext.getKernel().locate(MQTTBridge.SERVICE_NAME).getConfig()
                 .lookupTopics(CONFIGURATION_CONFIG_KEY).lookupTopics("mqtt");
@@ -154,10 +154,10 @@ public class ConfigTest {
 
         // verify that config changes take effect
         assertThat("session expiry interval config update",
-                () -> testContext.getLocalV5Client().getSessionExpiryInterval(), eventuallyEval(is(1L)));
-        assertThat("maximum packet size config update", () -> testContext.getLocalV5Client().getMaximumPacketSize(),
+                () -> testContext.getLocalV5Client().getConfig().getSessionExpiryInterval(), eventuallyEval(is(1L)));
+        assertThat("maximum packet size config update", () -> testContext.getLocalV5Client().getConfig().getMaximumPacketSize(),
                 eventuallyEval(is(1L)));
-        assertThat("receive maximum config update", () -> testContext.getLocalV5Client().getReceiveMaximum(),
+        assertThat("receive maximum config update", () -> testContext.getLocalV5Client().getConfig().getReceiveMaximum(),
                 eventuallyEval(is(1)));
 
         // Publish a large message to the local broker and verify that it is not received due to the local client's

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
@@ -56,18 +56,20 @@ public class LocalMqttClientFactory {
         switch (config.getMqttVersion()) {
             case MQTT5:
                 return new LocalMqtt5Client(
-                        config.getBrokerUri(),
-                        config.getClientId(),
-                        config.getSessionExpiryInterval(),
-                        config.getMaximumPacketSize(),
-                        config.getReceiveMaximum(),
-                        config.getAckTimeoutSeconds(),
-                        config.getConnAckTimeoutMs(),
-                        config.getPingTimeoutMs(),
-                        config.getKeepAliveTimeoutSeconds(),
-                        config.getMaxReconnectDelayMs(),
-                        config.getMinReconnectDelayMs(),
-                        config.getMqtt5RouteOptionsForSource(TopicMapping.TopicType.LocalMqtt),
+                        LocalMqtt5Client.Config.builder()
+                                .brokerUri(config.getBrokerUri())
+                                .clientId(config.getClientId())
+                                .sessionExpiryInterval(config.getSessionExpiryInterval())
+                                .maximumPacketSize(config.getMaximumPacketSize())
+                                .receiveMaximum(config.getReceiveMaximum())
+                                .ackTimeoutSeconds(config.getAckTimeoutSeconds())
+                                .connAckTimeoutMs(config.getConnAckTimeoutMs())
+                                .pingTimeoutMs(config.getPingTimeoutMs())
+                                .keepAliveTimeoutSeconds(config.getKeepAliveTimeoutSeconds())
+                                .maxReconnectDelayMs(config.getMaxReconnectDelayMs())
+                                .minReconnectDelayMs(config.getMinReconnectDelayMs())
+                                .optionsByTopic(config.getMqtt5RouteOptionsForSource(TopicMapping.TopicType.LocalMqtt))
+                                .build(),
                         mqttClientKeyStore,
                         executorService,
                         ses

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5ClientTest.java
@@ -138,18 +138,21 @@ class LocalMqtt5ClientTest {
     @Test
     void GIVEN_client_WHEN_port_is_missing_THEN_succeeds() throws Exception {
         client.stop();
-        client = new LocalMqtt5Client(URI.create("tcp://localhost"),
-                "test-client",
-                BridgeConfig.DEFAULT_SESSION_EXPIRY_INTERVAL,
-                BridgeConfig.DEFAULT_MAXIMUM_PACKET_SIZE,
-                BridgeConfig.DEFAULT_RECEIVE_MAXIMUM,
-                1L,
-                1L,
-                1L,
-                0L,
-                1L,
-                1L,
-                Collections.emptyMap(),
+        client = new LocalMqtt5Client(
+                LocalMqtt5Client.Config.builder()
+                        .brokerUri(URI.create("tcp://localhost"))
+                        .clientId("test-client")
+                        .sessionExpiryInterval(BridgeConfig.DEFAULT_SESSION_EXPIRY_INTERVAL)
+                        .maximumPacketSize(BridgeConfig.DEFAULT_MAXIMUM_PACKET_SIZE)
+                        .receiveMaximum(BridgeConfig.DEFAULT_RECEIVE_MAXIMUM)
+                        .ackTimeoutSeconds(1L)
+                        .connAckTimeoutMs(1L)
+                        .pingTimeoutMs(1L)
+                        .keepAliveTimeoutSeconds(0L)
+                        .maxReconnectDelayMs(1L)
+                        .minReconnectDelayMs(1L)
+                        .optionsByTopic(Collections.emptyMap())
+                        .build(),
                 mock(MQTTClientKeyStore.class),
                 executorService,
                 null);
@@ -485,18 +488,20 @@ class LocalMqtt5ClientTest {
 
     private void createLocalMqtt5ClientWithMqtt5Options(Map<String, Mqtt5RouteOptions> opts) throws MessageClientException {
         client = new LocalMqtt5Client(
-                URI.create("tcp://localhost:1883"),
-                "test-client",
-                BridgeConfig.DEFAULT_SESSION_EXPIRY_INTERVAL,
-                BridgeConfig.DEFAULT_MAXIMUM_PACKET_SIZE,
-                BridgeConfig.DEFAULT_RECEIVE_MAXIMUM,
-                1L,
-                1L,
-                1L,
-                0L,
-                1L,
-                1L,
-                opts,
+                LocalMqtt5Client.Config.builder()
+                        .brokerUri(URI.create("tcp://localhost:1883"))
+                        .clientId("test-client")
+                        .sessionExpiryInterval(BridgeConfig.DEFAULT_SESSION_EXPIRY_INTERVAL)
+                        .maximumPacketSize(BridgeConfig.DEFAULT_MAXIMUM_PACKET_SIZE)
+                        .receiveMaximum(BridgeConfig.DEFAULT_RECEIVE_MAXIMUM)
+                        .ackTimeoutSeconds(1L)
+                        .connAckTimeoutMs(1L)
+                        .pingTimeoutMs(1L)
+                        .keepAliveTimeoutSeconds(0L)
+                        .maxReconnectDelayMs(1L)
+                        .minReconnectDelayMs(1L)
+                        .optionsByTopic(opts)
+                        .build(),
                 mock(MQTTClientKeyStore.class),
                 executorService,
                 ses,


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Move local mqtt5 client configuration fields to a builder class

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
