### PR TITLE
feat: reset mqtt5 client on config change

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestExtension.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestExtension.java
@@ -47,6 +47,7 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyStoreException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
@@ -293,15 +294,9 @@ public class BridgeIntegrationTestExtension implements AfterTestExecutionCallbac
                         scheme,
                         context.getBrokerHost(),
                         "ssl".equalsIgnoreCase(scheme) ? context.getBrokerSSLPort() : context.getBrokerTCPPort()));
-
-        // wait for bridge to restart
-        CountDownLatch bridgeRunning = new CountDownLatch(1);
-        kernel.getContext().addGlobalStateChangeListener((GreengrassService service, State was, State newState) -> {
-            if (service.getName().equals(MQTTBridge.SERVICE_NAME) && newState.equals(State.RUNNING)) {
-                bridgeRunning.countDown();
-            }
-        });
-        assertTrue(bridgeRunning.await(30L, TimeUnit.SECONDS));
+        // v5 client resets by itself, give time for disconnect to happen
+        // TODO find a more reliable way
+        Thread.sleep(Duration.ofSeconds(5).toMillis());
     }
 
     @SuppressWarnings("PMD.TooFewBranchesForASwitchStatement")

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -28,7 +28,6 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Utilities for accessing MQTT Bridge configuration.
@@ -333,21 +332,5 @@ public final class BridgeConfig {
             opts.put(mapping.getTopic(), mqtt5RouteOptions.get(route));
         }
         return opts;
-    }
-
-    /**
-     * Determine if the component needs to be reinstalled, based on configuration change.
-     *
-     * @param newConfig new configuration
-     * @return true if the component should be reinstalled
-     */
-    public boolean reinstallRequired(BridgeConfig newConfig) {
-        return !Objects.equals(getBrokerUri(), newConfig.getBrokerUri())
-                || !Objects.equals(getClientId(), newConfig.getClientId())
-                || !Objects.equals(getMqttVersion(), newConfig.getMqttVersion())
-                || !Objects.equals(getSessionExpiryInterval(), newConfig.getSessionExpiryInterval())
-                || !Objects.equals(getMaximumPacketSize(), newConfig.getMaximumPacketSize())
-                || !Objects.equals(getReceiveMaximum(), newConfig.getReceiveMaximum())
-                || !Objects.equals(getMqtt5RouteOptions(), newConfig.getMqtt5RouteOptions());
     }
 }

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqttClientFactory.java
@@ -7,7 +7,6 @@ package com.aws.greengrass.mqtt.bridge.clients;
 
 
 import com.aws.greengrass.mqtt.bridge.BridgeConfig;
-import com.aws.greengrass.mqtt.bridge.TopicMapping;
 import com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore;
 import com.aws.greengrass.mqtt.bridge.model.BridgeConfigReference;
 import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
@@ -56,28 +55,19 @@ public class LocalMqttClientFactory {
         switch (config.getMqttVersion()) {
             case MQTT5:
                 return new LocalMqtt5Client(
-                        LocalMqtt5Client.Config.builder()
-                                .brokerUri(config.getBrokerUri())
-                                .clientId(config.getClientId())
-                                .sessionExpiryInterval(config.getSessionExpiryInterval())
-                                .maximumPacketSize(config.getMaximumPacketSize())
-                                .receiveMaximum(config.getReceiveMaximum())
-                                .ackTimeoutSeconds(config.getAckTimeoutSeconds())
-                                .connAckTimeoutMs(config.getConnAckTimeoutMs())
-                                .pingTimeoutMs(config.getPingTimeoutMs())
-                                .keepAliveTimeoutSeconds(config.getKeepAliveTimeoutSeconds())
-                                .maxReconnectDelayMs(config.getMaxReconnectDelayMs())
-                                .minReconnectDelayMs(config.getMinReconnectDelayMs())
-                                .optionsByTopic(config.getMqtt5RouteOptionsForSource(TopicMapping.TopicType.LocalMqtt))
-                                .build(),
+                        LocalMqtt5Client.Config.fromBridgeConfig(config),
                         mqttClientKeyStore,
                         executorService,
                         ses
                 );
             case MQTT3: // fall-through
             default:
-                return new MQTTClient(config.getBrokerUri(), config.getClientId(),
-                        mqttClientKeyStore, executorService);
+                return new MQTTClient(
+                        config.getBrokerUri(),
+                        config.getClientId(),
+                        mqttClientKeyStore,
+                        executorService
+                );
         }
     }
 }

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/MockMqtt5Client.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/MockMqtt5Client.java
@@ -69,6 +69,8 @@ public class MockMqtt5Client {
     private final Mqtt5ClientOptions.LifecycleEvents lifecycleEvents;
     private final Mqtt5ClientOptions.PublishEvents publishEvents;
     private final AtomicInteger timesToFailStart = new AtomicInteger();
+    @Getter
+    private final AtomicInteger numDisconnects = new AtomicInteger();
 
 
     public MockMqtt5Client(@NonNull Mqtt5ClientOptions.LifecycleEvents lifecycleEvents,
@@ -92,6 +94,7 @@ public class MockMqtt5Client {
         }).when(client).start();
 
         lenient().doAnswer(ignored -> {
+            numDisconnects.incrementAndGet();
             offline(DisconnectPacket.DisconnectReasonCode.NORMAL_DISCONNECTION);
             return null;
         }).when(client).stop(any());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Reset local mqtt5 client on config changes rather than reinstall bridge.

**Why is this change necessary:**
Improves customer experience by only interrupting local client rather than unnecessarily interrupting the entire bridge.

**How was this change tested:**
New unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
