### PR TITLE
fix: clear topics if disconnected without a session

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -210,6 +210,7 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
                 // Need to resubscribe to dropped topics
                 synchronized (subscriptionsLock) {
                     toSubscribeLocalMqttTopics.addAll(subscribedLocalMqttTopics);
+                    subscribedLocalMqttTopics.clear();
                 }
             }
 

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/MockMqtt5Client.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/MockMqtt5Client.java
@@ -265,6 +265,12 @@ public class MockMqtt5Client {
     }
 
     private void onDisconnection(DisconnectPacket.DisconnectReasonCode reasonCode) {
+        if (cleanSession) {
+            synchronized (subscriptionsLock) {
+                subscriptions.clear();
+            }
+        }
+
         DisconnectPacket disconnectPacket = mock(DisconnectPacket.class);
         lenient().when(disconnectPacket.getReasonCode()).thenReturn(reasonCode);
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix mqtt5 client such that when we reconnect without a session, topics are resubscribed. Currently no topics will resubscribe.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
