### PR TITLE
fix: 0 quiescence time for mqtt 3 disconnect and 120s shutdown timeout

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/MQTTBridge.java
@@ -40,6 +40,9 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import javax.inject.Inject;
 
+import static com.aws.greengrass.lifecyclemanager.Lifecycle.LIFECYCLE_SHUTDOWN_NAMESPACE_TOPIC;
+import static com.aws.greengrass.lifecyclemanager.Lifecycle.TIMEOUT_NAMESPACE_TOPIC;
+
 
 @ImplementsService(name = MQTTBridge.SERVICE_NAME)
 public class MQTTBridge extends PluginService {
@@ -103,6 +106,13 @@ public class MQTTBridge extends PluginService {
         this.configurationChangeHandler = new ConfigurationChangeHandler();
         this.certificateAuthorityChangeHandler = new CertificateAuthorityChangeHandler();
         this.bridgeConfig = bridgeConfig;
+
+        // Increase default service shutdown time to 120s
+        Topic shutdownTimeoutTopic =
+                config.lookup(SERVICE_LIFECYCLE_NAMESPACE_TOPIC, LIFECYCLE_SHUTDOWN_NAMESPACE_TOPIC,
+                        TIMEOUT_NAMESPACE_TOPIC);
+        shutdownTimeoutTopic.withParentNeedsToKnow(false);
+        shutdownTimeoutTopic.dflt(120);
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
@@ -167,8 +167,15 @@ public class MQTTClient implements MessageClient<MqttMessage> {
         mqttClientKeyStore.unsubscribeFromUpdates(onKeyStoreUpdate);
         removeMappingAndSubscriptions();
         try {
+            if (connectFuture != null) {
+                connectFuture.cancel(true);
+            }
+
             if (mqttClientInternal.isConnected()) {
-                mqttClientInternal.disconnect();
+                LOGGER.debug("Disconnecting MQTT client");
+                // 0ms quiescence time, just send the disconnect packet immediately
+                mqttClientInternal.disconnect(0);
+                LOGGER.debug("MQTT client disconnected");
             }
             dataStore.close();
         } catch (MqttException e) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
We see that bridge can timeout when shutting down due to the MQTT 3 client taking time to disconnect. We do not know if this is due to the quiescence of 30s default or not, but this change just sets it to 0 time to quiesce. Also increasing the shutdown timeout from 15s to 120s.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
