### PR TITLE
fix: close mqtt3 client on stop

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MessageClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MessageClient.java
@@ -31,7 +31,7 @@ public interface MessageClient<T extends Message> {
 
     T convertMessage(Message message);
 
-    void start();
+    void start() throws MessageClientException;
 
     void stop();
 }

--- a/src/test/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClientTest.java
+++ b/src/test/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClientTest.java
@@ -61,7 +61,7 @@ public class MQTTClientTest {
     }
 
     @Test
-    void GIVEN_mqttClient_WHEN_start_THEN_clientConnects() {
+    void GIVEN_mqttClient_WHEN_start_THEN_clientConnects() throws MessageClientException {
         MQTTClient mqttClient = new MQTTClient(ENCRYPTED_URI, CLIENT_ID, mockMqttClientKeyStore, ses, fakeMqttClient);
         mqttClient.start();
         fakeMqttClient.waitForConnect(1000);
@@ -70,7 +70,7 @@ public class MQTTClientTest {
     }
 
     @Test
-    void GIVEN_subscribedMqttClient_WHEN_stop_THEN_clientUnsubscribes() {
+    void GIVEN_subscribedMqttClient_WHEN_stop_THEN_clientUnsubscribes() throws MessageClientException {
         MQTTClient mqttClient = new MQTTClient(ENCRYPTED_URI, CLIENT_ID, mockMqttClientKeyStore, ses, fakeMqttClient);
         mqttClient.start();
         fakeMqttClient.waitForConnect(1000);
@@ -93,7 +93,7 @@ public class MQTTClientTest {
     }
 
     @Test
-    void GIVEN_subscribedMqttClient_WHEN_updateSubscriptions_THEN_subscriptionsUpdated() {
+    void GIVEN_subscribedMqttClient_WHEN_updateSubscriptions_THEN_subscriptionsUpdated() throws MessageClientException {
         MQTTClient mqttClient = new MQTTClient(ENCRYPTED_URI, CLIENT_ID, mockMqttClientKeyStore, ses, fakeMqttClient);
         mqttClient.start();
         fakeMqttClient.waitForConnect(1000);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adding a call to `IMqttClient#close` when shutting down to ensure paho client is fully closed.  Because we close the client, client creation has been moved to `start()` instead of in the constructor.

**Why is this change necessary:**
Due to previous change where reconnect in paho callback is async, it was discovered that this reconnect will happen even after stopping MQTTClient.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
