### PR TITLE
fix: ensure connect loop stops on client close

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/BridgeConfig.java
@@ -57,8 +57,8 @@ public final class BridgeConfig {
     public static final String KEY_MAXIMUM_PACKET_SIZE = "maximumPacketSize";
     public static final String KEY_SESSION_EXPIRY_INTERVAL = "sessionExpiryInterval";
     public static final String KEY_MQTT_5_ROUTE_OPTIONS = "mqtt5RouteOptions";
-    static final String KEY_MQTT = "mqtt";
-    static final String KEY_VERSION = "version";
+    public static final String KEY_MQTT = "mqtt";
+    public static final String KEY_VERSION = "version";
 
 
     private static final long MIN_TIMEOUT = 0L;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1) Always attempt to disconnect, so paho can close the client (paho won't close if connect is in progress).  
2) Explicitly bail from connect loop if paho client is closed.
3) also fixes a bug where subscription state isn't cleared before a `reset()`

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
