### PR TITLE
feat: ssl for mqtt3 integ tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>io.moquette</groupId>
             <artifactId>moquette-broker</artifactId>
-            <version>0.15</version>
+            <version>0.17</version>
             <scope>test</scope>
         </dependency>
         <!-- for running hivemq -->

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/KeystoreTest.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.mqtt.bridge.BridgeConfig;
 import com.aws.greengrass.mqtt.bridge.MQTTBridge;
 import com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore;
+import com.aws.greengrass.mqtt.bridge.model.MqttVersion;
 import com.aws.greengrass.util.Pair;
 import lombok.Builder;
 import lombok.Setter;
@@ -73,6 +74,13 @@ public class KeystoreTest {
         testContext.getCerts().waitForBrokerToApplyStoreChanges();
         numConnects.get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(testContext.getLocalV5Client().getClient().getIsConnected());
+    }
+
+    @BridgeIntegrationTest(
+            withConfig = "mqtt3_config_ssl.yaml",
+            withBrokers = Broker.MQTT3, // TODO hivemq doesn't play nicely with v3 paho client for some reason
+            withLocalClientVersions = MqttVersion.MQTT3)
+    void GIVEN_bridge_with_ssl_WHEN_bridge_starts_THEN_client_connects_over_ssl() {
     }
 
     @BridgeIntegrationTest(

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/LifecycleTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/LifecycleTest.java
@@ -26,7 +26,6 @@ import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
 import com.aws.greengrass.util.Pair;
-import io.moquette.BrokerConstants;
 import io.moquette.broker.Server;
 import io.moquette.broker.config.IConfig;
 import io.moquette.broker.config.MemoryConfig;
@@ -127,7 +126,8 @@ class LifecycleTest {
 
     private static Server startMoquette() throws IOException {
         IConfig brokerConf = new MemoryConfig(new Properties());
-        brokerConf.setProperty(BrokerConstants.PORT_PROPERTY_NAME, String.valueOf(8883));
+        brokerConf.setProperty(IConfig.PORT_PROPERTY_NAME, String.valueOf(8883));
+        brokerConf.setProperty(IConfig.ENABLE_TELEMETRY_NAME, "false");
         Server moquette = new Server();
         moquette.startServer(brokerConf);
         return moquette;

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestContext.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/BridgeIntegrationTestContext.java
@@ -51,7 +51,7 @@ public class BridgeIntegrationTestContext {
     public MQTTClient getLocalV3Client() {
         MessageClient<MqttMessage> client = getFromContext(MQTTBridge.class).getLocalMqttClient();
         if (!(client instanceof MQTTClient)) {
-            throw new RuntimeException("Excepted " + MQTTClient.class.getSimpleName()
+            throw new RuntimeException("Expected " + MQTTClient.class.getSimpleName()
                     + " but got " + client.getClass().getSimpleName());
         }
         return (MQTTClient) client;
@@ -60,7 +60,7 @@ public class BridgeIntegrationTestContext {
     public LocalMqtt5Client getLocalV5Client() {
         MessageClient<MqttMessage> client = getFromContext(MQTTBridge.class).getLocalMqttClient();
         if (!(client instanceof LocalMqtt5Client)) {
-            throw new RuntimeException("Excepted " + MQTTClient.class.getSimpleName()
+            throw new RuntimeException("Expected " + LocalMqtt5Client.class.getSimpleName()
                     + " but got " + client.getClass().getSimpleName());
         }
         return (LocalMqtt5Client) client;

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/Certs.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/extensions/Certs.java
@@ -49,7 +49,9 @@ public class Certs {
     private KeyStore serverKeyStore;
     private KeyStore serverTrustStore;
     private final MQTTClientKeyStore clientKeyStore;
+    @Getter
     private final Path keystorePath;
+    @Getter
     private final Path trustorePath;
 
     public Certs(MQTTClientKeyStore clientKeyStore,

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/config_with_mapping.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/config_with_mapping.yaml
@@ -1,7 +1,7 @@
 services:
   aws.greengrass.clientdevices.mqtt.Bridge:
     configuration:
-      brokerUri: 'tcp://localhost:8883'
+      brokerUri: 'tcp://localhost:1883'
       mqtt5RouteOptions:
         mapping1:
           noLocal: true

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/extensions/config.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/extensions/config.yaml
@@ -1,7 +1,7 @@
 services:
     aws.greengrass.clientdevices.mqtt.Bridge:
         configuration:
-            brokerUri: 'tcp://localhost:8883'
+            brokerUri: 'tcp://localhost:1883'
     main:
         dependencies:
             - aws.greengrass.clientdevices.mqtt.Bridge

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt3_config_ssl.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt3_config_ssl.yaml
@@ -5,7 +5,7 @@ services:
                 level: "DEBUG"
     aws.greengrass.clientdevices.mqtt.Bridge:
         configuration:
-            brokerUri: 'tcp://localhost:1883'
+            brokerUri: 'ssl://localhost:8883'
     main:
         dependencies:
             - aws.greengrass.clientdevices.mqtt.Bridge

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt3_local_and_iotcore.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt3_local_and_iotcore.yaml
@@ -1,7 +1,7 @@
 services:
   aws.greengrass.clientdevices.mqtt.Bridge:
     configuration:
-      brokerUri: 'tcp://localhost:8883'
+      brokerUri: 'tcp://localhost:1883'
       mqttTopicMapping:
         toIotCore:
           topic: topic/toIotCore

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_connect_options.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_connect_options.yaml
@@ -1,7 +1,7 @@
 services:
   aws.greengrass.clientdevices.mqtt.Bridge:
     configuration:
-      brokerUri: 'tcp://localhost:8883'
+      brokerUri: 'tcp://localhost:1883'
       mqttTopicMapping:
         toLocal:
           topic: topic/toLocal

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_and_iotcore.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_and_iotcore.yaml
@@ -1,7 +1,7 @@
 services:
   aws.greengrass.clientdevices.mqtt.Bridge:
     configuration:
-      brokerUri: 'tcp://localhost:8883'
+      brokerUri: 'tcp://localhost:1883'
       mqttTopicMapping:
         toIotCore:
           topic: topic/toIotCore

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_to_iotcore_nolocal.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_to_iotcore_nolocal.yaml
@@ -1,7 +1,7 @@
 services:
   aws.greengrass.clientdevices.mqtt.Bridge:
     configuration:
-      brokerUri: 'tcp://localhost:8883'
+      brokerUri: 'tcp://localhost:1883'
       mqtt5RouteOptions:
         toIotCore:
           noLocal: true

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_to_iotcore_retain_as_published.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/mqtt5_local_to_iotcore_retain_as_published.yaml
@@ -1,7 +1,7 @@
 services:
   aws.greengrass.clientdevices.mqtt.Bridge:
     configuration:
-      brokerUri: 'tcp://localhost:8883'
+      brokerUri: 'tcp://localhost:1883'
       mqtt5RouteOptions:
         toIotCore:
           retainAsPublished: true


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Configure SSL for Moquette within bridge's integration test extension.  This allows us to test SSL communication between bridge's local MQTT3 client and Moquette.

The Moquette version used for integ tests has also been bumped from 0.15 to 0.17, to match the latest version used in the public Greengrass Moquette component.

**Why is this change necessary:**

**How was this change tested:**
* New integ test that uses SSL between moquette and bridge mqtt3 client
 
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
