### PR TITLE
fix: improve MQTTClient shutdown reliability

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
@@ -162,7 +162,7 @@ public class MQTTClient implements MessageClient<MqttMessage> {
         connectAndSubscribe();
     }
 
-    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidCatchingNPE"})
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidCatchingNPE", "PMD.CloseResource"})
     private void disconnectForcibly() {
         IMqttClient client = mqttClientInternal;
         if (client == null) {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
@@ -209,7 +209,9 @@ public class MQTTClient implements MessageClient<MqttMessage> {
         try {
             // ensure that client cannot reconnect again
             // if callbacks would trigger for whatever reason
-            client.setCallback(null);
+            if (client != null) {
+                client.setCallback(null);
+            }
         } catch (NullPointerException ignore) {
             // can happen if client is closed.
             // ignoring as it is not a real error

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
@@ -164,10 +164,14 @@ public class MQTTClient implements MessageClient<MqttMessage> {
 
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidCatchingNPE"})
     private void disconnectForcibly() {
+        IMqttClient client = mqttClientInternal;
+        if (client == null) {
+            return;
+        }
         try {
             long doNotQuiesce = 0L;
             long doNotWaitForDisconnectPacket = 1L; // since 0L means no timeout
-            mqttClientInternal.disconnectForcibly(doNotQuiesce, doNotWaitForDisconnectPacket);
+            client.disconnectForcibly(doNotQuiesce, doNotWaitForDisconnectPacket);
         } catch (MqttException e) {
             LOGGER.atWarn().cause(e).log("Unable to disconnect forcibly");
         } catch (NullPointerException ignore) {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
@@ -207,9 +207,9 @@ public class MQTTClient implements MessageClient<MqttMessage> {
 
         IMqttClient client = mqttClientInternal;
         try {
-            // ensure that client cannot reconnect again
-            // if callbacks would trigger for whatever reason
             if (client != null) {
+                // ensure that client cannot reconnect again
+                // if callbacks would trigger for whatever reason
                 client.setCallback(null);
             }
         } catch (NullPointerException ignore) {

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
@@ -163,9 +163,6 @@ public class MQTTClient implements MessageClient<MqttMessage> {
     }
 
     private void disconnect() {
-        if (!mqttClientInternal.isConnected()) {
-            return;
-        }
         try {
             // 0ms quiescence time, don't wait for DISCONNECT
             mqttClientInternal.disconnectForcibly(0, 1L);
@@ -203,7 +200,11 @@ public class MQTTClient implements MessageClient<MqttMessage> {
     public void stop() {
         IMqttClient client = mqttClientInternal;
         if (client != null) {
-            client.setCallback(null); // clear callbacks to prevent accidental reconnection
+            try {
+                client.setCallback(null); // clear callbacks to prevent accidental reconnection
+            } catch (NullPointerException e) {
+                e.printStackTrace();
+            }
         }
 
         mqttClientKeyStore.unsubscribeFromUpdates(onKeyStoreUpdate);

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
@@ -198,15 +198,6 @@ public class MQTTClient implements MessageClient<MqttMessage> {
     @Override
     @SuppressWarnings("PMD.CloseResource")
     public void stop() {
-        IMqttClient client = mqttClientInternal;
-        if (client != null) {
-            try {
-                client.setCallback(null); // clear callbacks to prevent accidental reconnection
-            } catch (NullPointerException e) {
-                e.printStackTrace();
-            }
-        }
-
         mqttClientKeyStore.unsubscribeFromUpdates(onKeyStoreUpdate);
 
         cancelConnectTask();
@@ -219,6 +210,7 @@ public class MQTTClient implements MessageClient<MqttMessage> {
         }
 
         try {
+            IMqttClient client = mqttClientInternal;
             if (client != null) {
                 client.close();
             }

--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/MQTTClient.java
@@ -201,7 +201,11 @@ public class MQTTClient implements MessageClient<MqttMessage> {
     @Override
     @SuppressWarnings("PMD.CloseResource")
     public void stop() {
-        mqttClientInternal.setCallback(null); // clear callbacks to prevent accidental reconnection
+        IMqttClient client = mqttClientInternal;
+        if (client != null) {
+            client.setCallback(null); // clear callbacks to prevent accidental reconnection
+        }
+
         mqttClientKeyStore.unsubscribeFromUpdates(onKeyStoreUpdate);
 
         cancelConnectTask();
@@ -214,7 +218,6 @@ public class MQTTClient implements MessageClient<MqttMessage> {
         }
 
         try {
-            IMqttClient client = mqttClientInternal;
             if (client != null) {
                 client.close();
             }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

force disconnect on shutdown
* fixes issue where disconnect attempt fails due to client being connected (race condition between cancelling MQTTClient's async connect task and calling disconnect)

**Why is this change necessary:**

**How was this change tested:**
With integration test from https://github.com/aws-greengrass/aws-greengrass-mqtt-bridge/pull/163 that triggers the condition from 1)

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
