### PR TITLE
refactor: add cert and key getters to keystore

### DIFF
--- a/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
+++ b/src/main/java/com/aws/greengrass/mqtt/bridge/clients/LocalMqtt5Client.java
@@ -11,7 +11,6 @@ import com.aws.greengrass.mqtt.bridge.model.Mqtt5RouteOptions;
 import com.aws.greengrass.mqtt.bridge.model.MqttMessage;
 import com.aws.greengrass.mqttclient.v5.Publish;
 import com.aws.greengrass.util.CrashableSupplier;
-import com.aws.greengrass.util.EncryptionUtils;
 import com.aws.greengrass.util.RetryUtils;
 import com.aws.greengrass.util.Utils;
 import lombok.AccessLevel;
@@ -20,9 +19,6 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
-import org.bouncycastle.asn1.ASN1Encodable;
-import org.bouncycastle.asn1.ASN1Primitive;
-import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import software.amazon.awssdk.crt.CRT;
 import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.io.ClientTlsContext;
@@ -49,11 +45,9 @@ import software.amazon.awssdk.crt.mqtt5.packets.UserProperty;
 
 import java.io.IOException;
 import java.net.URI;
-import java.security.Key;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.time.Duration;
 import java.util.Collections;
@@ -71,8 +65,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore.DEFAULT_KEYSTORE_PASSWORD;
-import static com.aws.greengrass.mqtt.bridge.auth.MQTTClientKeyStore.KEY_ALIAS;
 import static com.aws.greengrass.mqtt.bridge.model.Mqtt5RouteOptions.DEFAULT_NO_LOCAL;
 
 @SuppressWarnings("PMD.CloseResource")
@@ -719,20 +711,9 @@ public class LocalMqtt5Client implements MessageClient<MqttMessage> {
                     .withMinReconnectDelayMs(config.getMinReconnectDelayMs());
 
             if (isSSL) {
-                // aws-c-io requires PKCS#1 key encoding for non-linux
-                // https://github.com/awslabs/aws-c-io/issues/260
-                // once this is resolved we can remove the conversion
-                Key key = mqttClientKeyStore.getKeyStore().getKey(KEY_ALIAS, DEFAULT_KEYSTORE_PASSWORD);
-                PrivateKeyInfo pkInfo = PrivateKeyInfo.getInstance(key.getEncoded());
-                ASN1Encodable privateKeyPKCS1ASN1Encodable = pkInfo.parsePrivateKey();
-                ASN1Primitive privateKeyPKCS1ASN1 = privateKeyPKCS1ASN1Encodable.toASN1Primitive();
-                byte[] privateKeyPKCS1 = privateKeyPKCS1ASN1.getEncoded();
-                String privateKey = EncryptionUtils.encodeToPem("RSA PRIVATE KEY", privateKeyPKCS1);
-
-                Certificate certificateData = mqttClientKeyStore.getKeyStore().getCertificate(KEY_ALIAS);
-                String certificatePem = EncryptionUtils.encodeToPem("CERTIFICATE", certificateData.getEncoded());
-
-                tlsContextOptions = TlsContextOptions.createWithMtls(certificatePem, privateKey);
+                tlsContextOptions = TlsContextOptions.createWithMtls(
+                        mqttClientKeyStore.getCertPem(),
+                        mqttClientKeyStore.getKeyPem());
                 tlsContextOptions.overrideDefaultTrustStore(
                         mqttClientKeyStore.getCaCertsAsString().orElseThrow(
                                 () -> new MQTTClientException("unable to set default trust store, "


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Move cert/key getting functionality into `MQTTClientKeystore`

**Why is this change necessary:**
These methods can be reused when replacing the mqtt3 client with aws iot client

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
