### PR TITLE
chore: bump GDK recipe dependency on CDA version

### DIFF
--- a/recipe.json
+++ b/recipe.json
@@ -7,7 +7,7 @@
   "ComponentPublisher": "{COMPONENT_PUBLISHER}",
   "ComponentDependencies": {
     "aws.greengrass.clientdevices.Auth": {
-      "VersionRequirement": ">=2.2.0 <2.3.0",
+      "VersionRequirement": ">=2.2.0 <2.5.0",
       "DependencyType": "HARD"
     }
   },


### PR DESCRIPTION
**Issue #, if available:**
Closes #168.


**Description of changes:**
Update GDK recipe to match real version in AWS.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
